### PR TITLE
Identify client to have personal tokens

### DIFF
--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -283,9 +283,10 @@ class Session:
                     )
                 )
             address = "http://" + parts[1] + "/token"
+            user_id = base64.b64encode(self.mail.encode()).decode("utf-8")
             blackbox_token = (
                 "tra:"
-                + requests.get(address, verify=config.do_ssl_verify, timeout=900).text
+                + requests.get(address, params={'user_id': user_id}, verify=config.do_ssl_verify, timeout=900).text
             )
             assert any(
                 c.isupper() for c in blackbox_token


### PR DESCRIPTION
Simple working concept for requesting personal tokens based on the user's encoded email address. Encodes self.mail and sends it to the API as an additional param.