### PR TITLE
Add loading of custom modules

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -40,6 +40,7 @@ from ikabot.function.trainArmy import trainArmy
 from ikabot.function.update import update
 from ikabot.function.vacationMode import vacationMode
 from ikabot.function.webServer import webServer
+from ikabot.function.loadCustomModule import loadCustomModule
 from ikabot.helpers.botComm import telegramDataIsValid, updateTelegramData
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import read
@@ -142,7 +143,8 @@ def menu(session, checkUpdate=True):
         144: decaptchaConf,
         145: logs,
         146: testTelegramBot,
-        147: importExportCookie
+        147: importExportCookie,
+        148: loadCustomModule
     }
 
     print(_("(0)  Exit"))
@@ -234,8 +236,9 @@ def menu(session, checkUpdate=True):
         print(_("(5) Logs"))
         print(_("(6) Message Telegram Bot"))
         print(_("(7) Import / Export cookie"))
+        print(_("(8) Load custom ikabot module"))
 
-        selected = read(min=0, max=7, digit=True)
+        selected = read(min=0, max=8, digit=True)
         if selected == 0:
             menu(session)
             return

--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -170,7 +170,11 @@ def menu(session, checkUpdate=True):
     print(_("(20) Dump / View world"))
     print(_("(21) Options / Settings"))
     total_options = len(menu_actions) + 1
-    selected = read(min=0, max=total_options, digit=True)
+    selected = read(min=0, max=total_options, digit=True, empty=True)
+    
+    # refresh main menu on hitting enter
+    if selected == '':
+        return menu(session)
 
     if selected == 7:
         banner()

--- a/ikabot/function/loadCustomModule.py
+++ b/ikabot/function/loadCustomModule.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-import gettext
 import sys
 import traceback
 from ikabot.helpers.pedirInfo import read, enter
@@ -8,10 +7,6 @@ from ikabot.helpers.gui import *
 from ikabot.config import *
 
 from importlib.machinery import SourceFileLoader
-
-t = gettext.translation('loadCustomModule', localedir, languages=languages, fallback=True)
-_ = t.gettext
-
 
 def loadCustomModule(session, event, stdin_fd, predetermined_input):
     """

--- a/ikabot/function/loadCustomModule.py
+++ b/ikabot/function/loadCustomModule.py
@@ -1,0 +1,90 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+import gettext
+import sys
+import traceback
+from ikabot.helpers.pedirInfo import read, enter
+from ikabot.helpers.gui import *
+from ikabot.config import *
+
+from importlib.machinery import SourceFileLoader
+
+t = gettext.translation('loadCustomModule', localedir, languages=languages, fallback=True)
+_ = t.gettext
+
+
+def loadCustomModule(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    sys.stdin = os.fdopen(stdin_fd)
+    config.predetermined_input = predetermined_input
+    try:
+        banner()
+        sessionData = session.getSessionData()
+        modules = [path for path in sessionData.get('shared', {}).get('customModules', []) if os.path.isfile(path)]
+        print("0) Back")
+        print("1) Add new module")
+        for module in modules:
+            print(str(modules.index(module) + 2) + ") " + module)
+
+        choice = read(min = 0, max = len(modules) + 1, digit = True)
+        if choice == 0:
+            event.set()
+            return
+        elif choice == 1:
+            banner()
+            print(f'        {bcolors.WARNING}[WARNING]{bcolors.ENDC} Running third party code could be dangerous!\n\n')
+            print('Enter the full path to the module you wish to load. The module must have a function with the same name as the file.')
+            print('Enter full path: ')
+            path = read().strip().replace('\\', '/')
+            if not path.endswith('.py'):
+                print('The file must be a .py file!')
+                enter()
+                event.set()
+                return
+
+            modules.append(path)
+            sessionData = session.getSessionData()
+            sessionData['shared'] = sessionData.get('shared', {})
+            sessionData['shared']['customModules'] = modules
+            session.setSessionData(sessionData['shared'], shared = True)
+
+        else:    
+            path = modules[choice - 2]
+
+        name = path.split('/')[-1].split('.')[0]
+
+        banner()
+
+        # Load module
+        try:
+            temp = SourceFileLoader(name,path).load_module()
+        except Exception as e:
+            print(f'Error while loading {path}: ' + str(e) + '\n' + traceback.format_exc())
+            enter()
+            event.set()
+            return
+        
+        # Call the function with the same name as the file
+        try:
+            exec('temp.' + name + '(session, event, stdin_fd, predetermined_input)')
+        except Exception as e:
+            print(f'Error while running {name} in {path}: ' + str(e) + '\n' + traceback.format_exc())
+            enter()
+            event.set()
+            return
+        
+        event.set()
+        return
+
+      
+    except KeyboardInterrupt:
+        event.set()
+        return
+    


### PR DESCRIPTION
This PR introduces a new way for users to load their own - or modified versions of the official - ikabot modules.

Users will simply select the Load custom ikabot module option under the Options / Settings page of the main menu and then they will be presented with a list of previously loaded custom modules, and an option to add new custom modules. The data for the module locations is saved under the 'shared' key in the session data (making is lobby-account specific). 
If a module is no longer present (if the path no longer exists) then it is removed from the list of known custom modules.

Also made main menu refresh on hitting enter.