### PR TITLE
fix speed regular expression on attackBarbarians

### DIFF
--- a/ikabot/function/attackBarbarians.py
+++ b/ikabot/function/attackBarbarians.py
@@ -358,7 +358,7 @@ def get_unit_data(session, city_id, unit_id):
     weight = int(weight)
 
     speed = re.search(
-        r'(\d+)\s*<br\/>\s*<span class="textLabel">.*?\s*:<\/span>\d+<br\/>\s*<\/div>\s*<div class="clearfloat"><\/div>\s*<div class="weapon">',
+        r'<span class="textLabel">Speed:</span>\s*(\d+)\s*<br/>',
         html,
     ).group(1)
     speed = int(speed)


### PR DESCRIPTION
### Description:
This pull request addresses an issue in the attackBarbarians function where the regular expression was failing to match the expected content. The problem was due to a mismatch in the regex pattern, which has now been corrected to properly extract the desired value from the HTML response.

### Changes:
* Fixed the regular expression in the attackBarbarians function to correctly match the speed value from the HTML response.
* Updated the code to ensure no further errors are thrown related to the regex pattern.
* Tested the change locally to verify that the issue has been resolved.

### Motivation:
The previous regular expression was not correctly capturing the intended data from the response, leading to potential failures in the functionality. This fix ensures the extraction of the speed value works as expected.

### Testing:
I have tested the changes by running the code in the project’s environment, and the regex now correctly matches the speed value without errors.

### Additional Notes:
* The regex fix ensures that we’re now targeting the correct HTML structure to extract the required data.
* No other parts of the codebase were impacted by this change.
* Game language must be English.

**releated issue:** #219 
