### PR TITLE
Reworked logging to use the logging module

### DIFF
--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -4,9 +4,8 @@
 import gettext
 import locale
 import os
-import random
 
-# Version changed automatically by the release pipeline
+# Version is changed automatically by the release pipeline
 IKABOT_VERSION = "7.0.9"
 
 
@@ -27,6 +26,10 @@ _ = t.gettext
 update_msg = ""
 
 isWindows = os.name == "nt"
+
+
+LOGS_DIRECTORY_FILE = os.getenv("temp") + "/ikabot.log" if isWindows else "/tmp/ikabot.log"
+DEFAULT_LOG_LEVEL = 30 # Warning
 
 publicAPIServerDomain = "ikagod.twilightparadox.com"
 do_ssl_verify = True
@@ -92,17 +95,10 @@ piracyMissionWaitingTime = {
     9: 57600,
 }
 predetermined_input = []
-logLevelsText = ["DEBUG", "INFO", "WARN", "ERROR"]
 
 
-class logLevels:
-    DEBUG = 0
-    INFO = 1
-    WARN = 2
-    ERROR = 3
 
 
-logLevel = logLevels.WARN
 debugON_alertAttacks = False
 debugON_alertLowWine = False
 debugON_donationBot = False

--- a/ikabot/function/logs.py
+++ b/ikabot/function/logs.py
@@ -1,13 +1,9 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
-import base64
-import gettext
-import gzip
-import io
-import pprint
-import sys
 
-import requests
+import logging
+import gettext
+import sys
 
 from ikabot.config import *
 from ikabot.helpers.gui import *
@@ -16,7 +12,6 @@ from ikabot.helpers.pedirInfo import enter, read
 t = gettext.translation("logs", localedir, languages=languages, fallback=True)
 _ = t.gettext
 
-key = "Cy8JNToyOz0zUltBJFo3CiIgKyc1NwMyP1kJEzUjJFgzJQsGOAAJCz5EOFY="
 
 
 def logs(session, event, stdin_fd, predetermined_input):
@@ -30,11 +25,6 @@ def logs(session, event, stdin_fd, predetermined_input):
     """
     sys.stdin = os.fdopen(stdin_fd)
     config.predetermined_input = predetermined_input
-    global key
-    key = base64.b64decode(key).decode("utf-8")
-    key = "".join(
-        [chr(ord(key[i]) ^ ord("ikabot"[i % len("ikabot")])) for i in range(len(key))]
-    )
     try:
         while True:
             banner()
@@ -46,10 +36,11 @@ def logs(session, event, stdin_fd, predetermined_input):
                 event.set()
                 return
             elif choice == 1:
+                # TODO changing the log level doesn't work because of multiprocessing. When the switch to multithreading is made, this will work.
                 banner()
                 print(
                     "The current log level is: "
-                    + logLevelsText[session.logLevel]
+                    + logging.getLevelName(logging.getLogger().getEffectiveLevel())
                     + "\n"
                 )
                 print("0) DEBUG")
@@ -57,168 +48,37 @@ def logs(session, event, stdin_fd, predetermined_input):
                 print("2) WARN")
                 print("3) ERROR")
                 choice = read(min=0, max=3, digit=True)
-                session.updateLogLevel(choice)
+                if choice == 0:
+                    logging.getLogger().setLevel(logging.DEBUG)
+                elif choice == 1:
+                    logging.getLogger().setLevel(logging.INFO)
+                elif choice == 2:
+                    logging.getLogger().setLevel(logging.WARN)
+                elif choice == 3:
+                    logging.getLogger().setLevel(logging.ERROR)
                 print(
-                    "The log level has been set to: "
-                    + logLevelsText[session.logLevel]
+                    "The log level for this session has been set to: "
+                    + logging.getLevelName(logging.getLogger().getEffectiveLevel())
                     + "\n"
                 )
                 enter()
             else:
-                viewLogs(session)
+                viewLogs()
 
     except KeyboardInterrupt:
         event.set()
         return
 
 
-def viewLogs(session, sort="-date", page=0):
-    while True:
-
-        banner()
-        logs = session.getLogs(sort=sort, page=page)
-
-        displayLogs = [
-            (
-                "["
-                + bcolors.RED
-                + "ERROR"
-                + bcolors.ENDC
-                + "]"
-                + " "
-                + log["date"]
-                + " "
-                + log["message"][:50].replace("\n", "")
-                if log["level"] == 3
-                else (
-                    "["
-                    + bcolors.WARNING
-                    + "WARN "
-                    + bcolors.ENDC
-                    + "]"
-                    + " "
-                    + log["date"]
-                    + " "
-                    + log["message"][:50].replace("\n", "")
-                    if log["level"] == 2
-                    else (
-                        "["
-                        + bcolors.BLUE
-                        + "INFO "
-                        + bcolors.ENDC
-                        + "]"
-                        + " "
-                        + log["date"]
-                        + " "
-                        + log["message"][:50].replace("\n", "")
-                        if log["level"] == 1
-                        else "["
-                        + bcolors.GREEN
-                        + "DEBUG"
-                        + bcolors.ENDC
-                        + "]"
-                        + " "
-                        + log["date"]
-                        + " "
-                        + log["message"][:50].replace("\n", "")
-                    )
-                )
-            )
-            for log in logs
-        ]
-
-        printChoiceList(displayLogs)
-        print(
-            "Type in the number of the log you wish to see the details of. Press enter for next page, or type in back for previous page."
-        )
-        print(
-            "To sort this list type in the property by which to sort: 'level', 'date', 'message'"
-        )
-        choice = read(
-            min=1,
-            max=25,
-            additionalValues=["back", "level", "date", "message", ""],
-            empty=True,
-        )
-        if str(choice).isdigit():
-            viewLogDetails(session, page, choice, sort)
-            viewLogs(session, sort=sort, page=page)
-        elif choice == "":
-            viewLogs(session, sort=sort, page=page + 1)
-        elif choice in ["level", "date", "message"]:
-            choice = (
-                "-" + choice if choice == sort else choice
-            )  # add - to sort so it reverses order if user typed it twice
-            viewLogs(session, sort=choice, page=0)
-        elif choice == "back" and (sort != "date" or page != 0):
-            return
-        else:
-            pass
-
-
-def viewLogDetails(session, page, log_number, sort):
-    try:
-        log = session.getLogs(page=page, sort=sort)[log_number - 1]
-        pprint.pprint(log, indent=4)
-        print(
-            "\nPress [Enter] to upload this log dump to pastebin. Or type in back to go back\
-               \nPlease beware that this log might contain identifiable information such as city, player and island ids and names."
-        )
-        choice = read(empty=True, values="back")
-        if choice == "back":
-            return
-        elif choice == "":
-            pass
-        choice = read(
-            msg="Do you wish to ommit the request history from the log before uploading it to pastebin? [Y|n]: ",
-            values=["n", "N", "Y", "y"],
-        )
-        if choice in ["y", "Y"]:
-            log["request_history"] = "None"
-        print("Posting to pastebin...")
-        print(post_to_pastebin(session, log))
-        enter()
-    except KeyboardInterrupt:
-        pass
-
-
-def post_to_pastebin(session, log):
-    try:
-
-        log["request_history"] = compress_str(log["request_history"])
-        response = requests.post(
-            "https://pastebin.com/api/api_post.php",
-            data={
-                "api_dev_key": base64.b64decode(key).decode("utf-8"),
-                "api_option": "paste",
-                "api_paste_code": pprint.pformat(log, indent=4),
-            },
-        )
-        assert (
-            response.status_code == 200
-        ), "Access code is not 200: {}\n text is: {}".format(
-            response.status_code, response.text
-        )
-        return "Access this log at " + response.text
-    except:
-        return "Error, paste failed!"
-
-
-def compress_str(str):
-    """Compresses string str and returns base64 value"""
-    s_bytes = str.encode("utf-8")
-    out = io.BytesIO()
-    with gzip.GzipFile(fileobj=out, mode="w") as f:
-        f.write(s_bytes)
-    return base64.b64encode(out.getvalue()).decode("utf-8")
-
-
-def decompress_str(str):
-    """Takes in a compressed string in base64 form and decompresses and decodes it
-    Use this function to decode the request history that is pasted in the pastebin!
-    """
-    s_bytes = base64.b64decode(str)
-    inp = io.BytesIO(s_bytes)
-    with gzip.GzipFile(fileobj=inp, mode="r") as f:
-        decompressed_bytes = f.read()
-    return decompressed_bytes.decode("utf-8")
+def viewLogs():
+    banner()
+    
+    # Display last 10kb of log form logfile
+    with open(LOGS_DIRECTORY_FILE, "rb") as f:
+        f.seek(0, 2)
+        size = f.tell()
+        f.seek(max(0, size - 10000))
+        print(f.read().decode("utf-8"))
+    
+    print(bcolors.DARK_GREEN + f"Above are displayed the last 10kb of the log file. The log file can be found at {LOGS_DIRECTORY_FILE}" + bcolors.ENDC)
+    enter()

--- a/ikabot/helpers/apiComm.py
+++ b/ikabot/helpers/apiComm.py
@@ -22,7 +22,7 @@ def getNewBlackBoxToken(session):
         blackbox token
     """
     address = (
-        getAddress(session, publicAPIServerDomain)
+        getAddress(publicAPIServerDomain)
         + "/v1/token"
         + "?user_agent="
         + session.user_agent
@@ -56,7 +56,7 @@ def getInteractiveCaptchaSolution(session, text_image, icons_image):
     solution : str
         solution of the captcha
     """
-    address = getAddress(session, publicAPIServerDomain) + "/v1/decaptcha/lobby"
+    address = getAddress(publicAPIServerDomain) + "/v1/decaptcha/lobby"
     files = {"text_image": text_image, "icons_image": icons_image}
     response = post(address, files=files, verify=do_ssl_verify, timeout=900)
     assert response.status_code == 200, (
@@ -87,7 +87,7 @@ def getPiratesCaptchaSolution(session, image):
     solution : str
         solution of the captcha
     """
-    address = getAddress(session, publicAPIServerDomain) + "/v1/decaptcha/pirate"
+    address = getAddress(publicAPIServerDomain) + "/v1/decaptcha/pirate"
     files = {"image": image}
     response = post(address, files=files, verify=do_ssl_verify, timeout=900)
     assert response.status_code == 200, (

--- a/ikabot/helpers/botComm.py
+++ b/ikabot/helpers/botComm.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from ikabot.helpers.logging import getLogger
+logger = getLogger(__name__)
 import gettext
 import json
 import os
@@ -47,19 +49,10 @@ def sendToBot(session, msg, Token=False, Photo=None):
         a bytes object representing a picture to be sent.
     """
 
-    session.writeLog(
-        msg="MESSAGE TO TG BOT: " + msg,
-        module=__name__,
-        level=logLevels.WARN,
-        logTraceback=True,
-        logRequestHistory=True,
-    )
+    logger.warning(f"MESSAGE TO TG BOT: {msg}", exc_info=True)
+
     if checkTelegramData(session) is False:
-        session.writeLog(
-            msg="Tried to message TG bot without correct tg data!",
-            module=__name__,
-            level=logLevels.ERROR,
-        )
+        logger.error("Tried to message TG bot without correct tg data!", exc_info=True)
         return
     if Token is False:
         msg = "pid:{}\n{}\n{}".format(os.getpid(), config.infoUser, msg)

--- a/ikabot/helpers/dns.py
+++ b/ikabot/helpers/dns.py
@@ -1,6 +1,8 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+from ikabot.helpers.logging import getLogger
+logger = getLogger(__name__)
 import socket
 import struct
 
@@ -128,7 +130,7 @@ def getDNSTXTRecordWithNSlookup(domain, DNS_server="8.8.8.8"):
     return "http://" + parts[1]
 
 
-def getAddressWithSocket(session, domain):
+def getAddressWithSocket(domain):
     """Makes multiple attempts to obtain the ikabot public API server address with the socket library
     Returns
     -------
@@ -138,36 +140,19 @@ def getAddressWithSocket(session, domain):
     try:
         return getDNSTXTRecordWithSocket(domain, "ns2.afraid.org")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from ns2.afraid.org, trying with 8.8.8.8: "
-            + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from ns2.afraid.org, trying with 8.8.8.8: ", exc_info=True)
     try:
         return getDNSTXTRecordWithSocket(domain, "8.8.8.8")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from 8.8.8.8, trying with 1.1.1.1: "
-            + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from 8.8.8.8, trying with 1.1.1.1: ", exc_info=True)
     try:
         return getDNSTXTRecordWithSocket(domain, "1.1.1.1")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from 1.1.1.1: " + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from 1.1.1.1: ", exc_info=True)
         raise e
 
 
-def getAddressWithNSlookup(session, domain):
+def getAddressWithNSlookup(domain):
     """Makes multiple attempts to obtain the ikabot public API server address with the nslookup tool if it's installed
     Returns
     -------
@@ -177,52 +162,23 @@ def getAddressWithNSlookup(session, domain):
     try:
         return getDNSTXTRecordWithNSlookup(domain, "ns2.afraid.org")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from nslookup with ns2.afraid.org: "
-            + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from ns2.afraid.org: ", exc_info=True)
     try:
         return getDNSTXTRecordWithNSlookup(domain, "")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from nslookup with system default DNS server: "
-            + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from nslookup with system default DNS server: ", exc_info=True)
     try:
         return getDNSTXTRecordWithNSlookup(domain, "8.8.8.8")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from nslookup with 8.8.8.8: " + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from nslookup with 8.8.8.8: ", exc_info=True)
     try:
         return getDNSTXTRecordWithNSlookup(domain, "1.1.1.1")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from nslookup with 1.1.1.1: " + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from nslookup with 1.1.1.1: ", exc_info=True)
         raise e
 
 
-def getAddress(
-    session=type(
-        "test",
-        (object,),
-        {"writeLog": lambda *args, **kwargs: print(str(args) + " " + str(kwargs))},
-    )(),
-    domain="ikagod.twilightparadox.com",
-):
+def getAddress(domain="ikagod.twilightparadox.com"):
     """Makes multiple attempts to obtain the ikabot public API server address
     Parameters
     ----------
@@ -237,35 +193,19 @@ def getAddress(
     if custom_address:
         return custom_address
     try:
-        address = getAddressWithSocket(session, domain)
+        address = getAddressWithSocket(domain)
         assert "." in address or ":" in address.replace("http://", ""), (
             "Bad server address: " + address
         )
         return address.replace("/ikagod/ikabot", "")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from socket, falling back to nslookup: "
-            + str(e),
-            level=logLevels.WARN,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.warning("Failed to obtain public API address from socket, falling back to nslookup: ", exc_info=True)
     try:
-        address = getAddressWithNSlookup(session, domain)
+        address = getAddressWithNSlookup(domain)
         assert "." in address or ":" in address.replace("http://", ""), (
             "Bad server address: " + address
         )  # address is either hostname, IPv4 or IPv6
         return address.replace("/ikagod/ikabot", "")
     except Exception as e:
-        session.writeLog(
-            "Failed to obtain public API address from both socket and nslookup: "
-            + str(e),
-            level=logLevels.ERROR,
-            module=__name__,
-            logTraceback=True,
-        )
+        logger.error("Failed to obtain public API address from both socket and nslookup: ", exc_info=True)
         raise e
-
-
-# session = type('test', (object,), {'writeLog': lambda *args, **kwargs: print(str(args) + ' ' + str(kwargs))})() # Useful mock session object for testing
-# print(getAddress(session, 'ikagod.twilightparadox.com'))

--- a/ikabot/helpers/logging.py
+++ b/ikabot/helpers/logging.py
@@ -1,0 +1,37 @@
+"""
+This module will set up proper ikabot logging when imported.
+"""
+
+import logging
+import logging.handlers
+
+from ikabot.config import LOGS_DIRECTORY_FILE, DEFAULT_LOG_LEVEL
+
+# TODO wrap logging functions to remove cookies from logs, or add a filter
+class IkabotLogger(logging.Logger):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+logging.setLoggerClass(IkabotLogger)    
+
+# Create custom file logger
+rotatingFileHandler = logging.handlers.RotatingFileHandler(
+                filename=LOGS_DIRECTORY_FILE,
+                maxBytes=10 * 1024 * 1024, #max logfile size is 10 MB
+                backupCount=10, # max number of log files is 10
+                    )
+logConfig = {
+    'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    'level': DEFAULT_LOG_LEVEL,
+    'force': True,
+    'handlers': [rotatingFileHandler]
+    }
+logging.basicConfig(**logConfig)
+
+# Make sure to set all loggers to propagate and clear their handlers (only use the root logger)
+for name in logging.root.manager.loggerDict:
+    logging.getLogger(name).propagate = True
+    logging.getLogger(name).handlers.clear()
+    
+def getLogger(name: str) -> IkabotLogger:
+    """Convenience function to get a logger by name"""
+    return logging.getLogger(name)


### PR DESCRIPTION
Just as the title implies, the overly complicated logging system I wrote a while ago is no more. Now ikabot will use the good old `logging` module from the python standard library.

- The default location of the log file is /tmp/ikabot.log on Unix or %temp%/ikabot.log on Windows
- The default log level is WARN
- The log files maximum size is 10MB
- The maximum number of historical log files is 10
- The maximum length of the log display within ikabot is 1MB (will display last 1MB worth of the log file)
- Changing the log level currently **DOES NOT WORK**, but it will work once ikabot is working with multi-threading instead of multi-processing as it is right now.
- There is a TODO comment in the logging.py file indicating that cookies will have to be omitted from the logs once the session data is reworked as well.