### PR TITLE
fix: Refactor: check favor once per cycle before donating to all godids

### DIFF
--- a/ikabot/function/activateShrine.py
+++ b/ikabot/function/activateShrine.py
@@ -70,13 +70,13 @@ def do_it(session, godids, mode, times):
 
         if mode == 1 or mode == 3:
             for _ in range(times):
+                favor = getFavor(session, cityid, pos)
+                while favor < favor_needed:
+                    session.setStatus(
+                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
+                    )
+                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
                 for godid in godids:
-                    favor = getFavor(session, cityid, pos)
-                    while favor < favor_needed:
-                        session.setStatus(
-                            f"Not enough favor @{getDateTime()}, re-trying in 3h."
-                        )
-                        time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
                     donateShrine(session, godid, cityid, pos)
                     time.sleep(2)
 
@@ -87,13 +87,13 @@ def do_it(session, godids, mode, times):
 
         if mode == 2:
             while True:
+                favor = getFavor(session, cityid, pos)
+                while favor < favor_needed:
+                    session.setStatus(
+                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
+                    )
+                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
                 for godid in godids:
-                    favor = getFavor(session, cityid, pos)
-                    while favor < favor_needed:
-                        session.setStatus(
-                            f"Not enough favor @{getDateTime()}, re-trying in 3h."
-                        )
-                        time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
                     donateShrine(session, godid, cityid, pos)
                     time.sleep(2)
                 for i in range(6):  # 12h * 6 = 72 hours


### PR DESCRIPTION
Now checks favor once per activation cycle before looping over godids, instead of checking favor for each godid.
