### PR TITLE
fix: marketplace offers not displayed due to locale-specific thousand separators

### DIFF
--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -70,59 +70,42 @@ def getOffers(session, city):
     offers : list[dict]
     """
     html = getMarketHtml(session, city)
-    hits = re.findall(
-        r'short_text80">(.*?) <br/>\((.*?)\)\s*</td>\s*<td>(\d+)</td>\s*<td>([\d,\s]+)(?:<div class="tooltip">.*?)?</td>\s*<td><img src="([^"]+\.png)"[\s\S]*?white-space:nowrap;">(\d+)\s*[\s\S]*?href="\?view=takeOffer&destinationCityId=(\d+)&oldView=branchOffice&activeTab=bargain&cityId=(\d+)&position=(\d+)&type=(\d+)&resource=(\w+)"',
-        html,
-        re.DOTALL
-    )
 
-    # Clean up the hits by stripping whitespace from each captured string
-    cleaned_hits = []
-    for hit in hits:
-        cleaned_hit = tuple(item.strip() for item in hit)  # Strip whitespace from each item
-        cleaned_hits.append(cleaned_hit)
-    hits = cleaned_hits
-        
+    resource_names = {
+        "resource": "wood",
+        "1": "wine",
+        "2": "marble",
+        "3": "glass",
+        "4": "sulfur",
+    }
+
     offers = []
-    for hit in hits:
-        offer = {
-            "ciudadDestino": hit[0],
-            "jugadorAComprar": hit[1],
-            "bienesXminuto": int(hit[2]),
-            "amountAvailable": int(
-                hit[3].replace(",", "").replace(".", "").replace("<", "").replace(" ", "").replace("\xa0", "")
-            ),
-            "tipo": hit[4],
-            "precio": int(hit[5]),
-            "destinationCityId": hit[6],
-            "cityId": hit[7],
-            "position": hit[8],
-            "type": hit[9],
-            "resource": hit[10],
-        }
+    for row in re.findall(r'<tr[^>]*>([\s\S]*?)</tr>', html):
+        city_match   = re.search(r'<td class="short_text80">(.*?)<br/>\((.*?)\)', row)
+        amount_match = re.search(r'<div class="tooltip">([\d,.]+)</div>', row)
+        price_match  = re.search(r'<td style="white-space:nowrap;">(\d+)', row)
+        href_match   = re.search(
+            r'href="\?view=takeOffer&destinationCityId=(\d+)&oldView=branchOffice&activeTab=bargain&cityId=(\d+)&position=(\d+)&type=(\d+)&resource=(\w+)"',
+            row,
+        )
 
-        # Parse CDN Images to material type
-        if offer["tipo"] == "//gf2.geo.gfsrv.net/cdn19/c3527b2f694fb882563c04df6d8972.png":
-            offer["tipo"] = "wood"
-        elif (
-            offer["tipo"] == "//gf1.geo.gfsrv.net/cdnc6/94ddfda045a8f5ced3397d791fd064.png"
-        ):
-            offer["tipo"] = "wine"
-        elif (
-            offer["tipo"] == "//gf3.geo.gfsrv.net/cdnbf/fc258b990c1a2a36c5aeb9872fc08a.png"
-        ):
-            offer["tipo"] = "marble"
-        elif (
-            offer["tipo"] == "//gf2.geo.gfsrv.net/cdn1e/417b4059940b2ae2680c070a197d8c.png"
-        ):
-            offer["tipo"] = "glass"
-        elif (
-            offer["tipo"] == "//gf1.geo.gfsrv.net/cdn9b/5578a7dfa3e98124439cca4a387a61.png"
-        ):
-            offer["tipo"] = "sulfur"
-        else:
+        if not all([city_match, amount_match, price_match, href_match]):
             continue
 
+        resource_key = href_match.group(5)
+        raw_amount = amount_match.group(1).replace('.', '').replace(',', '')
+        offer = {
+            "ciudadDestino": city_match.group(1).strip(),
+            "jugadorAComprar": city_match.group(2).strip(),
+            "amountAvailable": int(raw_amount),
+            "tipo": resource_names.get(resource_key, resource_key),
+            "precio": int(price_match.group(1)),
+            "destinationCityId": href_match.group(1),
+            "cityId": href_match.group(2),
+            "position": href_match.group(3),
+            "type": href_match.group(4),
+            "resource": resource_key,
+        }
         offers.append(offer)
     return offers
 

--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -182,6 +182,7 @@ def buyResources(session, event, stdin_fd, predetermined_input):
 
         # get all the offers of the chosen resource from the chosen city
         offers = getOffers(session, city)
+        offers.sort(key=lambda o: o["precio"])
         if len(offers) == 0:
             print("There are no offers available.")
             enter()

--- a/ikabot/function/sellResources.py
+++ b/ikabot/function/sellResources.py
@@ -101,7 +101,7 @@ def getOffers(session, my_market_city, resource_type):
     processed_offers = []
     for row in re.findall(r'<tr[^>]*>([\s\S]*?)</tr>', html):
         city_match   = re.search(r'<td class="short_text80">(.*?)<br/>\((.*?)\)', row)
-        amount_match = re.search(r'<div class="tooltip">([\d,]+)</div>', row)
+        amount_match = re.search(r'<div class="tooltip">([\d,.]+)</div>', row)
         price_match  = re.search(r'<td style="white-space:nowrap;">(\d+)', row)
         dist_match   = re.search(r'<td>(\d+)</td>', row)
         dest_match   = re.search(r'href="\?view=takeOffer&destinationCityId=(\d+)', row)
@@ -109,10 +109,11 @@ def getOffers(session, my_market_city, resource_type):
         if not all([city_match, amount_match, price_match, dist_match, dest_match]):
             continue
 
+        raw_amount = amount_match.group(1).replace('.', '').replace(',', '')
         processed_offers.append((
             city_match.group(1).strip(),
             city_match.group(2).strip(),
-            int(amount_match.group(1).replace(',', '')),
+            int(raw_amount),
             int(price_match.group(1)),
             int(dist_match.group(1)),
             int(dest_match.group(1)),

--- a/ikabot/function/sellResources.py
+++ b/ikabot/function/sellResources.py
@@ -98,16 +98,26 @@ def getOffers(session, my_market_city, resource_type):
     resp = session.post(params=data)
     html = json.loads(resp, strict=False)[1][1][1]
 
-    offers_found = re.findall(
-        r'<td class="short_text80">(.*?)<br/>\((.*?)\)[\s\S]*?<div class="tooltip">([\d,]+)</div>[\s\S]*?<td style="white-space:nowrap;">(\d+)[\s\S]*?<td>(\d+)</td>[\s\S]*?href="\?view=takeOffer&destinationCityId=(\d+)',
-        html
-    )
-    # Process the found offers, removing commas and converting to integers
     processed_offers = []
-    for city_name, user_name, amount, price, dist, dest_id in offers_found:
-        clean_amount = int(amount.replace(',', ''))
-        processed_offers.append((city_name.strip(), user_name.strip(), clean_amount, int(price), int(dist), int(dest_id)))
-    
+    for row in re.findall(r'<tr[^>]*>([\s\S]*?)</tr>', html):
+        city_match   = re.search(r'<td class="short_text80">(.*?)<br/>\((.*?)\)', row)
+        amount_match = re.search(r'<div class="tooltip">([\d,]+)</div>', row)
+        price_match  = re.search(r'<td style="white-space:nowrap;">(\d+)', row)
+        dist_match   = re.search(r'<td>(\d+)</td>', row)
+        dest_match   = re.search(r'href="\?view=takeOffer&destinationCityId=(\d+)', row)
+
+        if not all([city_match, amount_match, price_match, dist_match, dest_match]):
+            continue
+
+        processed_offers.append((
+            city_match.group(1).strip(),
+            city_match.group(2).strip(),
+            int(amount_match.group(1).replace(',', '')),
+            int(price_match.group(1)),
+            int(dist_match.group(1)),
+            int(dest_match.group(1)),
+        ))
+
     return processed_offers
 
 


### PR DESCRIPTION
  ## Problem

  Both Buy Resources and Sell Resources showed "no offers available" even when offers existed in the game. The root cause was that the HTML parsers
  failed silently when the game server returned amounts formatted with period as a thousand separator (e.g. `250.000` in Portuguese/European locales)
   instead of comma (`250,000`).

  ### Sell Resources (`sellResources.py`)
  The original regex used a single cross-document pattern with `[\s\S]*?` spanning multiple table rows, causing two issues:
  1. `[\d,]+` did not match period-separated amounts like `250.000`, so no offers were captured
  2. Cross-row `[\s\S]*?` contamination meant only 1 offer would be returned even when multiple existed

  ### Buy Resources (`buyResources.py`)
  The original regex had the same amount pattern issue (`[\d,\s]+` not matching `.`), plus resource type detection relied on hardcoded CDN image URLs
   that may have changed, causing all matched offers to be silently discarded via `else: continue`.

  ## Fix

  - Replaced single cross-document regex with row-by-row `<tr>` parsing in both files
  - Updated amount regex from `[\d,]+` / `[\d,\s]+` to `[\d,.]+` to handle both comma and period thousand separators
  - Amount parsing already stripped both separators (`replace('.', '').replace(',', '')`) — now the regex actually captures those values
  - In `buyResources.py`: replaced fragile CDN image URL matching for resource type with the `resource` parameter already present in the offer href
  - Offers are now sorted by price ascending before display and purchase, so the cheapest offer is always bought first

  ## Tested

  Verified on a Portuguese locale game server where amounts use `.` as thousand separator. Both Buy Resources and Sell Resources now correctly list all available offers.