### PR TITLE
feat: add Discord webhook notifications

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -46,7 +46,8 @@ from ikabot.function.vacationMode import vacationMode
 from ikabot.function.webServer import webServer
 from ikabot.function.loadCustomModule import loadCustomModule
 from ikabot.function.activateShrine import activateShrine
-from ikabot.helpers.botComm import telegramDataIsValid, updateTelegramData
+from ikabot.helpers.botComm import telegramDataIsValid, updateTelegramData, discordDataIsValid, updateDiscordData
+from ikabot.function.testDiscordBot import testDiscordBot
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.process import updateProcessList
@@ -149,14 +150,16 @@ def menu(session, checkUpdate=True):
         2001: searchForIslandSpaces,
         2002: dumpWorld,
         2101: proxyConf,
-        2102: updateTelegramData,
         2103: killTasks,
         2104: decaptchaConf,
         2105: logs,
-        2106: testTelegramBot,
-        2107: importExportCookie,
-        2108: loadCustomModule,
-        2109: developer,
+        2106: importExportCookie,
+        2107: loadCustomModule,
+        2108: developer,
+        210211: updateTelegramData,
+        210212: testTelegramBot,
+        210221: updateDiscordData,
+        210222: testDiscordBot,
         22: consolidateResources,
         2301: modifyProduction,
         2302: modifyAcademyWorkers,
@@ -291,24 +294,65 @@ def menu(session, checkUpdate=True):
         banner()
         print("(0) Back")
         print("(1) Configure Proxy")
-        if telegramDataIsValid(session):
-            print("(2) Change the Telegram data")
-        else:
-            print("(2) Enter the Telegram data")
+        print("(2) Notifications")
         print("(3) Kill tasks")
         print("(4) Configure captcha resolver")
         print("(5) Logs")
-        print("(6) Message Telegram Bot")
-        print("(7) Import / Export cookie")
-        print("(8) Load custom ikabot module")
-        print("(9) Developer Data")
+        print("(6) Import / Export cookie")
+        print("(7) Load custom ikabot module")
+        print("(8) Developer Data")
 
-        selected = read(min=0, max=9, digit=True)
+        selected = read(min=0, max=8, digit=True)
         if selected == 0:
             menu(session)
             return
         if selected > 0:
             selected += 2100
+
+    if selected == 2102:
+        banner()
+        print("(0) Back")
+        print("(1) Telegram")
+        print("(2) Discord")
+
+        selected = read(min=0, max=2, digit=True)
+        if selected == 0:
+            menu(session)
+            return
+        if selected > 0:
+            selected += 21020
+
+    if selected == 21021:
+        banner()
+        print("(0) Back")
+        if telegramDataIsValid(session):
+            print("(1) Change the Telegram data")
+        else:
+            print("(1) Enter the Telegram data")
+        print("(2) Test Telegram Bot")
+
+        selected = read(min=0, max=2, digit=True)
+        if selected == 0:
+            menu(session)
+            return
+        if selected > 0:
+            selected += 210210
+
+    if selected == 21022:
+        banner()
+        print("(0) Back")
+        if discordDataIsValid(session):
+            print("(1) Change the Discord webhook")
+        else:
+            print("(1) Enter the Discord webhook")
+        print("(2) Test Discord Bot")
+
+        selected = read(min=0, max=2, digit=True)
+        if selected == 0:
+            menu(session)
+            return
+        if selected > 0:
+            selected += 210220
 
     if selected not in menu_actions and selected != 0:
         print("Invalid option")

--- a/ikabot/function/testDiscordBot.py
+++ b/ikabot/function/testDiscordBot.py
@@ -1,0 +1,33 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+import sys
+
+from ikabot.helpers.botComm import discordDataIsValid, sendToDiscord
+from ikabot.helpers.gui import *
+from ikabot.helpers.pedirInfo import enter, read
+
+
+def testDiscordBot(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    sys.stdin = os.fdopen(stdin_fd)
+    config.predetermined_input = predetermined_input
+    try:
+        if not discordDataIsValid(session):
+            print("No Discord webhook configured. Please set it up first.")
+            enter()
+            event.set()
+            return
+        input = read(msg="Enter the message you wish to see: ")
+        msg = "Test message: {}".format(input)
+        sendToDiscord(session, msg)
+        enter()
+        event.set()
+    except KeyboardInterrupt:
+        event.set()

--- a/ikabot/function/testDiscordBot.py
+++ b/ikabot/function/testDiscordBot.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import sys
 
-from ikabot.helpers.botComm import discordDataIsValid, sendToDiscord
+from ikabot.helpers.botComm import discordDataIsValid, sendToBot
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import enter, read
 
@@ -26,7 +26,7 @@ def testDiscordBot(session, event, stdin_fd, predetermined_input):
             return
         input = read(msg="Enter the message you wish to see: ")
         msg = "Test message: {}".format(input)
-        sendToDiscord(session, msg)
+        sendToBot(session, msg)
         enter()
         event.set()
     except KeyboardInterrupt:

--- a/ikabot/helpers/botComm.py
+++ b/ikabot/helpers/botComm.py
@@ -16,6 +16,73 @@ from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import read
 
 
+def sendToDiscord(session, msg):
+    """Send a message to a Discord webhook if one is configured.
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    msg : str
+    """
+    sessionData = session.getSessionData()
+    try:
+        webhook_url = sessionData["shared"]["discord"]["webhookUrl"]
+    except KeyError:
+        return
+    if not webhook_url:
+        return
+    try:
+        get(webhook_url, json={"content": msg})
+    except Exception:
+        pass
+
+
+def discordDataIsValid(session):
+    """Return True if a Discord webhook URL is stored in session data.
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    """
+    sessionData = session.getSessionData()
+    try:
+        return len(sessionData["shared"]["discord"]["webhookUrl"]) > 0
+    except KeyError:
+        return False
+
+
+def updateDiscordData(session, event=None, stdin_fd=None, predetermined_input=[]):
+    """Ask the user for a Discord webhook URL and save it to session data.
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd : int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    if event is not None and stdin_fd is not None:
+        sys.stdin = os.fdopen(stdin_fd)
+    config.predetermined_input = predetermined_input
+    banner()
+    print("To create a Discord webhook:")
+    print("1. Open your Discord server settings > Integrations > Webhooks")
+    print("2. Click 'New Webhook', choose a channel, and copy the webhook URL\n")
+    webhook_url = read(msg="Webhook URL: ").strip()
+    if not webhook_url:
+        if event is not None:
+            event.set()
+        return False
+    discord_data = {"discord": {"webhookUrl": webhook_url}}
+    session.setSessionData(discord_data, shared=True)
+    try:
+        get(webhook_url, json={"content": "Discord notifications successfully configured for ikabot."})
+        print("\nA test message was sent to your Discord channel.")
+    except Exception:
+        print("\nWebhook URL saved, but the test message could not be sent. Please verify the URL.")
+    enter()
+    if event is not None:
+        event.set()
+    return True
+
+
 def sendToBotDebug(session, msg, debugON):
     """This function will send the ``msg`` argument passed to it as a message to the user on Telegram, only if ``debugOn`` is ``True``
     Parameters
@@ -46,6 +113,8 @@ def sendToBot(session, msg, Token=False, Photo=None):
     """
 
     logger.warning(f"MESSAGE TO TG BOT: {msg}", exc_info=True)
+
+    sendToDiscord(session, msg)
 
     if checkTelegramData(session) is False:
         logger.error("Tried to message TG bot without correct tg data!", exc_info=True)

--- a/ikabot/helpers/botComm.py
+++ b/ikabot/helpers/botComm.py
@@ -9,7 +9,7 @@ import random
 import re
 import sys
 import time
-from requests import get
+from requests import get, post as requests_post
 import ikabot.config as config
 from ikabot.config import *
 from ikabot.helpers.gui import *
@@ -31,7 +31,7 @@ def sendToDiscord(session, msg):
     if not webhook_url:
         return
     try:
-        get(webhook_url, json={"content": msg})
+        requests_post(webhook_url, json={"content": msg})
     except Exception:
         pass
 
@@ -73,7 +73,7 @@ def updateDiscordData(session, event=None, stdin_fd=None, predetermined_input=[]
     discord_data = {"discord": {"webhookUrl": webhook_url}}
     session.setSessionData(discord_data, shared=True)
     try:
-        get(webhook_url, json={"content": "Discord notifications successfully configured for ikabot."})
+        requests_post(webhook_url, json={"content": "Discord notifications successfully configured for ikabot."})
         print("\nA test message was sent to your Discord channel.")
     except Exception:
         print("\nWebhook URL saved, but the test message could not be sent. Please verify the URL.")


### PR DESCRIPTION
  ## Summary

  Adds Discord webhook support as an optional notification channel alongside the existing Telegram integration. All notifications sent via `sendToBot` are now automatically delivered to Discord if a
  webhook URL is configured. Both channels are independent and can be active simultaneously.

  ## Changes

  ### `helpers/botComm.py`
  - Added `sendToDiscord()` — sends a message to the configured Discord webhook via POST
  - Added `discordDataIsValid()` — checks if a webhook URL is stored in session data
  - Added `updateDiscordData()` — prompts the user for a webhook URL, saves it to session data, and sends a test message
  - `sendToBot()` now calls `sendToDiscord()` automatically before the Telegram flow, so all existing notification calls gain Discord support without any changes to other files

  ### `function/testDiscordBot.py` (new)
  - New feature following the same pattern as `testTelegramBot`
  - Calls `sendToBot` so the test message is delivered to all configured channels

  ### `command_line.py`
  - Reorganised the Settings menu (21) to group Telegram and Discord under a dedicated **Notifications** submenu:

  **Settings → Notifications → Telegram → (1) Enter / Change Telegram data**
  **Settings → Notifications → Telegram → (2) Test Telegram Bot**
  **Settings → Notifications → Discord → (1) Enter / Change Discord webhook**
  **Settings → Notifications → Discord → (2) Test Discord Bot**

  ## How to configure Discord

  1. Open your Discord server settings → Integrations → Webhooks
  2. Click **New Webhook**, choose a channel and copy the webhook URL
  3. In ikabot go to **Settings → Notifications → Discord → Enter Discord webhook**
  4. Paste the webhook URL, a test message will be sent immediately to confirm

  ## Notes

  - Discord is fully optional. If no webhook is configured, all existing behaviour is unchanged.
  - No new dependencies. Uses `requests` which is already a project dependency.
  - All 87 existing `sendToBot` call sites gain Discord support automatically with no code changes required.