### PR TITLE
feat: constructionList.py total construction time, shortening construction time using the skip button when construction time under 5 minutes 

### DIFF
--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -22,8 +22,9 @@ isWindows = os.name == "nt"
 USE_MULTIPROCESSING_DECAPTCHA = True
 
 # Set to TRUE to enable requesting the zero-cost speedup while a building is finishing # default FALSE
-CONSTRUCTION_FREE_SPEEDUP = (os.getenv("CONSTRUCTION_FREE_SPEEDUP") or "FALSE").strip().upper() == "TRUE" 
-
+CONSTRUCTION_FREE_SPEEDUP = (os.getenv("CONSTRUCTION_FREE_SPEEDUP") or "FALSE").strip().upper() == "TRUE"
+# Max seconds to randomly wait before firing the free speedup request
+SPEEDUP_RANDOMWAIT = int(os.getenv("SPEEDUP_RANDOMWAIT") or 30)
 
 # Regional Settings
 # These environment variables can be set to match the user's browser region and

--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -24,7 +24,7 @@ USE_MULTIPROCESSING_DECAPTCHA = True
 # Set to TRUE to enable requesting the zero-cost speedup while a building is finishing # default FALSE
 CONSTRUCTION_FREE_SPEEDUP = (os.getenv("CONSTRUCTION_FREE_SPEEDUP") or "FALSE").strip().upper() == "TRUE"
 # Max seconds to randomly wait before firing the free speedup request
-SPEEDUP_RANDOMWAIT = int(os.getenv("SPEEDUP_RANDOMWAIT") or 30)
+SPEEDUP_RANDOMWAIT = max(1, int(os.getenv("SPEEDUP_RANDOMWAIT") or 30))
 
 # Regional Settings
 # These environment variables can be set to match the user's browser region and

--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -21,6 +21,10 @@ isWindows = os.name == "nt"
 # Set to False if your environment struggles with Python multiprocessing
 USE_MULTIPROCESSING_DECAPTCHA = True
 
+# Set to TRUE to enable requesting the zero-cost speedup while a building is finishing # default FALSE
+CONSTRUCTION_FREE_SPEEDUP = (os.getenv("CONSTRUCTION_FREE_SPEEDUP") or "FALSE").strip().upper() == "TRUE" 
+
+
 # Regional Settings
 # These environment variables can be set to match the user's browser region and
 # timezone when Gameforge rejects generated blackbox tokens.

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -54,9 +54,18 @@ def _parseConstructionTime(row):
     return None
 
 
+def _formatRemainingTime(seconds):
+    seconds = max(0, int(seconds))
+    days, seconds = divmod(seconds, 86400)
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+    values = ((days, "D"), (hours, "H"), (minutes, "M"), (seconds, "S"))
+    return " ".join("{}{}".format(value, unit) for value, unit in values if value) or "0S"
+
+
 def _findHtml(value, element_id):
     if isinstance(value, str):
-        return value if element_id in value else None
+        return value if element_id in value and "ambrosiaIcon" in value else None
     if isinstance(value, list):
         for item in value:
             result = _findHtml(item, element_id)
@@ -74,7 +83,7 @@ def _getFreeSpeedupParams(response, city_id, position):
     try:
         popup = _findHtml(json.loads(response, strict=False), "js_buildingSpeedupActivateBtn")
     except (TypeError, ValueError):
-        return None
+        popup = response if isinstance(response, str) else None
     if popup is None:
         return None
 
@@ -85,7 +94,10 @@ def _getFreeSpeedupParams(response, city_id, position):
     )
     if button is None:
         return None
-    cost = re.search(r'class=["\']ambrosiaIcon["\']>\s*(\d+)\s*</span>', button.group(0))
+    cost = re.search(
+        r'<span\b(?=[^>]*\bclass=["\'][^"\']*\bambrosiaIcon\b[^"\']*["\'])[^>]*>\s*(\d+)\s*</span>',
+        button.group(0),
+    )
     href = re.search(r'href=["\']([^"\']+)', button.group(0))
     if cost is None or cost.group(1) != "0" or href is None:
         return None
@@ -96,19 +108,19 @@ def _getFreeSpeedupParams(response, city_id, position):
         "function": "buildingSpeedup",
         "cityId": str(city_id),
         "position": str(position),
-        "backgroundView": "city",
-        "currentCityId": str(city_id),
     }
     if any(query.get(key) != [value] for key, value in required.items()):
         return None
-    if len(query.get("level", [])) != 1 or not query["level"][0].isdigit():
+    if query.get("currentCityId", [str(city_id)]) != [str(city_id)]:
         return None
-    if len(query.get("actionRequest", [])) != 1 or not query["actionRequest"][0]:
+    if len(query.get("level", [])) != 1 or not query["level"][0].isdigit():
         return None
 
     return {
         **required,
         "level": query["level"][0],
+        "backgroundView": "city",
+        "currentCityId": str(city_id),
         "actionRequest": actionRequest,
         "ajax": "1",
     }
@@ -133,7 +145,7 @@ def tryFreeBuildingSpeedup(session, city_id, building):
     return True
 
 
-def waitForConstruction(session, city_id, final_lvl):
+def waitForConstruction(session, city_id, final_lvl, construction_queue=None):
     """
     Parameters
     ----------
@@ -162,13 +174,26 @@ def waitForConstruction(session, city_id, final_lvl):
         current_time = int(time.time())
         final_time = int(construction_time)
         seconds_to_wait = final_time - current_time
+        current_remaining = max(0, seconds_to_wait - 300)
+        total_remaining = current_remaining + sum(construction_queue or [])
+        status = "{}: {} -> level {} | current {} | total {}".format(
+            city["cityName"],
+            construction_building["name"],
+            construction_building["level"] + 1,
+            _formatRemainingTime(seconds_to_wait),
+            _formatRemainingTime(total_remaining),
+        )
+        session.setStatus(status)
 
         if 0 < seconds_to_wait <= 300:
             if tryFreeBuildingSpeedup(session, city_id, construction_building):
+                session.setStatus(status + " | free speedup sent")
                 msg = "{}: Finished {} for 0 Ambrosia".format(
                     city["cityName"], construction_building["name"]
                 )
                 sendToBotDebug(session, msg, debugON_constructionList)
+            else:
+                session.setStatus(status + " | waiting for zero-cost speedup")
             wait(5)
             continue
 
@@ -179,17 +204,14 @@ def waitForConstruction(session, city_id, final_lvl):
             construction_building["level"] + 1,
         )
         sendToBotDebug(session, msg, debugON_constructionList)
-        session.setStatus(
-            f"Waiting until {getDateTime(time.time()+seconds_to_wait+10)[8:]}, {construction_building['name']} {construction_building['level']} -> {construction_building['level']+1} in {city['name']}, final lvl: {final_lvl}"
-        )
-        wait(max(5, seconds_to_wait - 300))
+        wait(min(30, max(5, seconds_to_wait - 300)))
 
     html = session.get(city_url + city_id)
     city = getCity(html)
     return city
 
 
-def expandBuilding(session, cityId, building, waitForResources):
+def expandBuilding(session, cityId, building, waitForResources, construction_queue=None):
     """
     Parameters
     ----------
@@ -209,7 +231,7 @@ def expandBuilding(session, cityId, building, waitForResources):
     )  # to avoid race conditions with sendResourcesNeeded
 
     for lv in range(levels_to_upgrade):
-        city = waitForConstruction(session, cityId, upgradeTo)
+        city = waitForConstruction(session, cityId, upgradeTo, construction_queue)
         building = city["position"][position]
 
         if building["canUpgrade"] is False and waitForResources is True:
@@ -251,13 +273,15 @@ def expandBuilding(session, cityId, building, waitForResources):
             sendToBot(session, msg)
             sendToBot(session, resp)
             return
+        if construction_queue:
+            construction_queue.pop(0)
 
         msg = "{}: The building {} is being extended to level {:d}.".format(
             city["cityName"], building["name"], building["level"] + 1
         )
         sendToBotDebug(session, msg, debugON_constructionList)
 
-    city = waitForConstruction(session, cityId, upgradeTo)
+    city = waitForConstruction(session, cityId, upgradeTo, construction_queue)
     building = city["position"][position]
     msg = "{}: The building {} finished extending to level: {:d}.".format(
         city["cityName"], building["name"], building["level"]
@@ -385,6 +409,7 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
     # calculate the cost of the entire upgrade, taking into account all the possible reductions
     final_costs = [0] * len(materials_names)
     construction_time = 0
+    construction_times = []
     levels_to_upgrade = 0
     for match in matches:
         lv = re.search(r'"level">(\d+)</td>', match).group(1)
@@ -398,7 +423,9 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
         levels_to_upgrade += 1
         level_time = _parseConstructionTime(match)
         if level_time is not None:
-            construction_time += max(0, level_time - 300)
+            level_time = max(0, level_time - 300)
+            construction_time += level_time
+            construction_times.append(level_time)
         # get the costs for the current level
         costs = re.findall(r'<td class="costs"><div.*>([\d,\.\s\xa0]*)</div></div></td>', match)
         # delete blank spaces (\xa0) in costs
@@ -443,6 +470,7 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
             return [-2, -2, -2, -2, -2]
 
     building["constructionTime"] = construction_time
+    building["constructionTimes"] = construction_times
     return final_costs
 
 
@@ -860,6 +888,11 @@ def constructionList(session, event, stdin_fd, predetermined_input):
         total_time = sum(building["constructionTime"] for building in buildings)
         active_time = int(city.get("endUpgradeTime", 0)) - int(time.time())
         total_time += max(0, active_time - 300)
+        construction_queue = [
+            duration
+            for building in buildings
+            for duration in building["constructionTimes"]
+        ]
         if buildings:
             print("\nTotal construction time: {}".format(daysHoursMinutes(total_time)))
 
@@ -872,6 +905,11 @@ def constructionList(session, event, stdin_fd, predetermined_input):
         return
     
     set_child_mode(session)
+    session.setStatus(
+        "{}: queued {} upgrades | total {}".format(
+            city["cityName"], len(construction_queue), _formatRemainingTime(total_time)
+        )
+    )
     event.set()
 
     building_log_name = buildings[0]["name"] if len(buildings) == 1 else "Multiple buildings"
@@ -882,7 +920,9 @@ def constructionList(session, event, stdin_fd, predetermined_input):
     try:
         if expand:
             for building in buildings:
-                expandBuilding(session, cityId, building, wait_resources)
+                expandBuilding(
+                    session, cityId, building, wait_resources, construction_queue
+                )
         elif thread:
             thread.join()
     except Exception as e:

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -176,7 +176,7 @@ def waitForConstruction(session, city_id, final_lvl, construction_queue=None):
         seconds_to_wait = final_time - current_time
         current_remaining = max(0, seconds_to_wait - 300)
         total_remaining = current_remaining + sum(construction_queue or [])
-        status = "{}: {} -> level {} | current {} | total {}".format(
+        status = "{}: {} -> level {} , current {} , total {}".format(
             city["cityName"],
             construction_building["name"],
             construction_building["level"] + 1,
@@ -187,13 +187,13 @@ def waitForConstruction(session, city_id, final_lvl, construction_queue=None):
 
         if 0 < seconds_to_wait <= 300:
             if tryFreeBuildingSpeedup(session, city_id, construction_building):
-                session.setStatus(status + " | free speedup sent")
+                session.setStatus(status + " , free speedup sent")
                 msg = "{}: Finished {} for 0 Ambrosia".format(
                     city["cityName"], construction_building["name"]
                 )
                 sendToBotDebug(session, msg, debugON_constructionList)
             else:
-                session.setStatus(status + " | waiting for zero-cost speedup")
+                session.setStatus(status + " , waiting for zero-cost speedup")
             wait(5)
             continue
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -12,6 +12,7 @@ import threading
 import time
 import traceback
 from decimal import *
+from urllib.parse import parse_qs, urlparse
 
 import requests
 from functools import cache
@@ -53,6 +54,85 @@ def _parseConstructionTime(row):
     return None
 
 
+def _findHtml(value, element_id):
+    if isinstance(value, str):
+        return value if element_id in value else None
+    if isinstance(value, list):
+        for item in value:
+            result = _findHtml(item, element_id)
+            if result is not None:
+                return result
+    if isinstance(value, dict):
+        for item in value.values():
+            result = _findHtml(item, element_id)
+            if result is not None:
+                return result
+    return None
+
+
+def _getFreeSpeedupParams(response, city_id, position):
+    try:
+        popup = _findHtml(json.loads(response, strict=False), "js_buildingSpeedupActivateBtn")
+    except (TypeError, ValueError):
+        return None
+    if popup is None:
+        return None
+
+    button = re.search(
+        r'<a\b(?=[^>]*\bid=["\']js_buildingSpeedupActivateBtn["\'])[^>]*>.*?</a>',
+        popup,
+        re.DOTALL,
+    )
+    if button is None:
+        return None
+    cost = re.search(r'class=["\']ambrosiaIcon["\']>\s*(\d+)\s*</span>', button.group(0))
+    href = re.search(r'href=["\']([^"\']+)', button.group(0))
+    if cost is None or cost.group(1) != "0" or href is None:
+        return None
+
+    query = parse_qs(urlparse(html.unescape(href.group(1))).query)
+    required = {
+        "action": "Premium",
+        "function": "buildingSpeedup",
+        "cityId": str(city_id),
+        "position": str(position),
+        "backgroundView": "city",
+        "currentCityId": str(city_id),
+    }
+    if any(query.get(key) != [value] for key, value in required.items()):
+        return None
+    if len(query.get("level", [])) != 1 or not query["level"][0].isdigit():
+        return None
+    if len(query.get("actionRequest", [])) != 1 or not query["actionRequest"][0]:
+        return None
+
+    return {
+        **required,
+        "level": query["level"][0],
+        "actionRequest": actionRequest,
+        "ajax": "1",
+    }
+
+
+def tryFreeBuildingSpeedup(session, city_id, building):
+    popup_params = {
+        "view": "buildingSpeedup",
+        "cityId": city_id,
+        "position": building["position"],
+        "backgroundView": "city",
+        "currentCityId": city_id,
+        "actionRequest": actionRequest,
+        "ajax": "1",
+    }
+    response = session.post(params=popup_params)
+    speedup_params = _getFreeSpeedupParams(response, city_id, building["position"])
+    if speedup_params is None:
+        return False
+
+    session.post(params=speedup_params)
+    return True
+
+
 def waitForConstruction(session, city_id, final_lvl):
     """
     Parameters
@@ -83,6 +163,15 @@ def waitForConstruction(session, city_id, final_lvl):
         final_time = int(construction_time)
         seconds_to_wait = final_time - current_time
 
+        if 0 < seconds_to_wait <= 300:
+            if tryFreeBuildingSpeedup(session, city_id, construction_building):
+                msg = "{}: Finished {} for 0 Ambrosia".format(
+                    city["cityName"], construction_building["name"]
+                )
+                sendToBotDebug(session, msg, debugON_constructionList)
+            wait(5)
+            continue
+
         msg = "{}: I wait {:d} seconds so that {} gets to the level {:d}".format(
             city["cityName"],
             seconds_to_wait,
@@ -93,7 +182,7 @@ def waitForConstruction(session, city_id, final_lvl):
         session.setStatus(
             f"Waiting until {getDateTime(time.time()+seconds_to_wait+10)[8:]}, {construction_building['name']} {construction_building['level']} -> {construction_building['level']+1} in {city['name']}, final lvl: {final_lvl}"
         )
-        wait(seconds_to_wait + 10)
+        wait(max(5, seconds_to_wait - 300))
 
     html = session.get(city_url + city_id)
     city = getCity(html)
@@ -168,8 +257,10 @@ def expandBuilding(session, cityId, building, waitForResources):
         )
         sendToBotDebug(session, msg, debugON_constructionList)
 
+    city = waitForConstruction(session, cityId, upgradeTo)
+    building = city["position"][position]
     msg = "{}: The building {} finished extending to level: {:d}.".format(
-        city["cityName"], building["name"], building["level"] + 1
+        city["cityName"], building["name"], building["level"]
     )
     sendToBotDebug(session, msg, debugON_constructionList)
 
@@ -307,7 +398,7 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
         levels_to_upgrade += 1
         level_time = _parseConstructionTime(match)
         if level_time is not None:
-            construction_time += level_time
+            construction_time += max(0, level_time - 300)
         # get the costs for the current level
         costs = re.findall(r'<td class="costs"><div.*>([\d,\.\s\xa0]*)</div></div></td>', match)
         # delete blank spaces (\xa0) in costs
@@ -767,7 +858,8 @@ def constructionList(session, event, stdin_fd, predetermined_input):
         buildings = confirmed_buildings
 
         total_time = sum(building["constructionTime"] for building in buildings)
-        total_time += max(0, int(city.get("endUpgradeTime", 0)) - int(time.time()))
+        active_time = int(city.get("endUpgradeTime", 0)) - int(time.time())
+        total_time += max(0, active_time - 300)
         if buildings:
             print("\nTotal construction time: {}".format(daysHoursMinutes(total_time)))
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -3,6 +3,7 @@
 
 
 import hashlib
+import html
 import json
 import math
 import random
@@ -30,6 +31,26 @@ from ikabot.web.session import normal_get
 sendResources = True
 expand = True
 thread = None
+
+
+def _parseConstructionTime(row):
+    cells = re.findall(r'<td class="costs">(.*?)</td>', row, re.DOTALL)
+    if not cells:
+        return None
+
+    cell = cells[-1]
+    match = re.search(r'data-(?:seconds|duration|time)=["\'](\d+)', cell)
+    if match:
+        return int(match.group(1))
+
+    values = re.findall(r'title=["\']([^"\']+)', cell)
+    values.append(re.sub(r"<[^>]+>", " ", html.unescape(cell)))
+    units = {"d": 86400, "h": 3600, "m": 60, "s": 1}
+    for value in values:
+        parts = re.findall(r"(\d+)\s*([dhms])", value.lower())
+        if parts:
+            return sum(int(amount) * units[unit] for amount, unit in parts)
+    return None
 
 
 def waitForConstruction(session, city_id, final_lvl):
@@ -272,6 +293,7 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
 
     # calculate the cost of the entire upgrade, taking into account all the possible reductions
     final_costs = [0] * len(materials_names)
+    construction_time = 0
     levels_to_upgrade = 0
     for match in matches:
         lv = re.search(r'"level">(\d+)</td>', match).group(1)
@@ -283,6 +305,9 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
             break
 
         levels_to_upgrade += 1
+        level_time = _parseConstructionTime(match)
+        if level_time is not None:
+            construction_time += level_time
         # get the costs for the current level
         costs = re.findall(r'<td class="costs"><div.*>([\d,\.\s\xa0]*)</div></div></td>', match)
         # delete blank spaces (\xa0) in costs
@@ -326,6 +351,7 @@ def getResourcesNeeded(session, city, building, current_level, final_level):
             #Skip only this building
             return [-2, -2, -2, -2, -2]
 
+    building["constructionTime"] = construction_time
     return final_costs
 
 
@@ -739,6 +765,11 @@ def constructionList(session, event, stdin_fd, predetermined_input):
 
         # Replace list
         buildings = confirmed_buildings
+
+        total_time = sum(building["constructionTime"] for building in buildings)
+        total_time += max(0, int(city.get("endUpgradeTime", 0)) - int(time.time()))
+        if buildings:
+            print("\nTotal construction time: {}".format(daysHoursMinutes(total_time)))
 
     except KeyboardInterrupt:
         event.set()

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -204,7 +204,7 @@ def waitForConstruction(session, city_id, final_lvl, construction_queue=None):
             construction_building["level"] + 1,
         )
         sendToBotDebug(session, msg, debugON_constructionList)
-        wait(min(30, max(5, seconds_to_wait - 300)))
+        wait(max(5, seconds_to_wait - 300))
 
     html = session.get(city_url + city_id)
     city = getCity(html)

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -141,7 +141,7 @@ def tryFreeBuildingSpeedup(session, city_id, building):
     if speedup_params is None:
         return False
         
-    wait(random.randint(4, SPEEDUP_RANDOMWAIT)) # random wait
+    wait(random.randint(1, SPEEDUP_RANDOMWAIT)) # random wait
     session.post(params=speedup_params)
     return True
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -140,7 +140,8 @@ def tryFreeBuildingSpeedup(session, city_id, building):
     speedup_params = _getFreeSpeedupParams(response, city_id, building["position"])
     if speedup_params is None:
         return False
-
+        
+    wait(random.randint(1, 30)) # random wait
     session.post(params=speedup_params)
     return True
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -141,7 +141,7 @@ def tryFreeBuildingSpeedup(session, city_id, building):
     if speedup_params is None:
         return False
         
-    wait(random.randint(1, 30)) # random wait
+    wait(random.randint(4, SPEEDUP_RANDOMWAIT)) # random wait
     session.post(params=speedup_params)
     return True
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -187,7 +187,7 @@ def waitForConstruction(session, city_id, final_lvl, construction_queue=None):
         session.setStatus(status)
 
         if 0 < seconds_to_wait <= 300:
-            if tryFreeBuildingSpeedup(session, city_id, construction_building):
+            if CONSTRUCTION_FREE_SPEEDUP and tryFreeBuildingSpeedup(session, city_id, construction_building):
                 session.setStatus(status + " , free speedup sent")
                 msg = "{}: Finished {} for 0 Ambrosia".format(
                     city["cityName"], construction_building["name"]

--- a/tests/ikabot/function/test_constructionList.py
+++ b/tests/ikabot/function/test_constructionList.py
@@ -1,0 +1,15 @@
+import unittest
+
+from ikabot.function.constructionList import _parseConstructionTime
+
+
+class TestParseConstructionTime(unittest.TestCase):
+    def test_parses_time_cell(self):
+        row = '<td class="level">2</td><td class="costs">100</td><td class="costs"><span title="1D 2H 3M 4S">1D 2H</span></td>'
+
+        self.assertEqual(_parseConstructionTime(row), 93784)
+
+    def test_prefers_seconds_attribute(self):
+        row = '<td class="level">2</td><td class="costs"><span data-duration="1234">20M</span></td>'
+
+        self.assertEqual(_parseConstructionTime(row), 1234)

--- a/tests/ikabot/function/test_constructionList.py
+++ b/tests/ikabot/function/test_constructionList.py
@@ -1,6 +1,12 @@
 import unittest
+import json
+from unittest.mock import Mock
 
-from ikabot.function.constructionList import _parseConstructionTime
+from ikabot.function.constructionList import (
+    _getFreeSpeedupParams,
+    _parseConstructionTime,
+    tryFreeBuildingSpeedup,
+)
 
 
 class TestParseConstructionTime(unittest.TestCase):
@@ -13,3 +19,38 @@ class TestParseConstructionTime(unittest.TestCase):
         row = '<td class="level">2</td><td class="costs"><span data-duration="1234">20M</span></td>'
 
         self.assertEqual(_parseConstructionTime(row), 1234)
+
+
+class TestFreeBuildingSpeedup(unittest.TestCase):
+    def _response(self, cost):
+        popup = '''<a class="button" id="js_buildingSpeedupActivateBtn"
+            href="?action=Premium&amp;function=buildingSpeedup&amp;cityId=14075&amp;position=10&amp;level=3&amp;backgroundView=city&amp;currentCityId=14075&amp;actionRequest=old">
+            Activate (<span title="Ambrosia" class="ambrosiaIcon">{}</span>)</a>'''.format(cost)
+        return json.dumps([["replaceElement", ["#buildingSpeedup", popup]]])
+
+    def test_rejects_nonzero_ambrosia_cost(self):
+        self.assertIsNone(_getFreeSpeedupParams(self._response(4), "14075", 10))
+
+    def test_builds_guarded_zero_cost_request(self):
+        params = _getFreeSpeedupParams(self._response(0), "14075", 10)
+
+        self.assertEqual(params["action"], "Premium")
+        self.assertEqual(params["function"], "buildingSpeedup")
+        self.assertEqual(params["level"], "3")
+
+    def test_rejects_zero_cost_request_for_another_position(self):
+        self.assertIsNone(_getFreeSpeedupParams(self._response(0), "14075", 11))
+
+    def test_never_posts_premium_request_for_nonzero_cost(self):
+        session = Mock()
+        session.post.return_value = self._response(4)
+
+        self.assertFalse(tryFreeBuildingSpeedup(session, "14075", {"position": 10}))
+        self.assertEqual(session.post.call_count, 1)
+
+    def test_posts_premium_request_for_zero_cost(self):
+        session = Mock()
+        session.post.side_effect = [self._response(0), "ok"]
+
+        self.assertTrue(tryFreeBuildingSpeedup(session, "14075", {"position": 10}))
+        self.assertEqual(session.post.call_count, 2)

--- a/tests/ikabot/function/test_constructionList.py
+++ b/tests/ikabot/function/test_constructionList.py
@@ -3,6 +3,7 @@ import json
 from unittest.mock import Mock
 
 from ikabot.function.constructionList import (
+    _formatRemainingTime,
     _getFreeSpeedupParams,
     _parseConstructionTime,
     tryFreeBuildingSpeedup,
@@ -19,6 +20,9 @@ class TestParseConstructionTime(unittest.TestCase):
         row = '<td class="level">2</td><td class="costs"><span data-duration="1234">20M</span></td>'
 
         self.assertEqual(_parseConstructionTime(row), 1234)
+
+    def test_formats_remaining_seconds(self):
+        self.assertEqual(_formatRemainingTime(927), "15M 27S")
 
 
 class TestFreeBuildingSpeedup(unittest.TestCase):
@@ -40,6 +44,31 @@ class TestFreeBuildingSpeedup(unittest.TestCase):
 
     def test_rejects_zero_cost_request_for_another_position(self):
         self.assertIsNone(_getFreeSpeedupParams(self._response(0), "14075", 11))
+
+    def test_accepts_raw_popup_with_reordered_span_attributes(self):
+        response = self._response(0)
+        popup = json.loads(response)[0][1][1].replace(
+            'title="Ambrosia" class="ambrosiaIcon"',
+            'class="ambrosiaIcon" title="Ambrosia"',
+        )
+
+        self.assertIsNotNone(_getFreeSpeedupParams(popup, "14075", 10))
+
+    def test_ignores_earlier_button_reference_in_ajax_response(self):
+        response = json.loads(self._response(0))
+        response.insert(0, ["update", ["#js_buildingSpeedupActivateBtn"]])
+
+        self.assertIsNotNone(
+            _getFreeSpeedupParams(json.dumps(response), "14075", 10)
+        )
+
+    def test_allows_popup_to_omit_replaceable_request_metadata(self):
+        response = self._response(0).replace(
+            "&amp;backgroundView=city&amp;currentCityId=14075&amp;actionRequest=old",
+            "",
+        )
+
+        self.assertIsNotNone(_getFreeSpeedupParams(response, "14075", 10))
 
     def test_never_posts_premium_request_for_nonzero_cost(self):
         session = Mock()


### PR DESCRIPTION
I implemented and tested total construction time for all queued construction jobs and implemented the automatic construction shortening using the skip button when the remaining time is under 5 minutes. The skip is only activated when its Ambrosia cost is exactly zero. And only when the remaining time is below 5 minutes. It does double speed ups when after the first speed up, the construction isn't finished. Resolving issues #327 #150 .


I git rebased my commits in the middle, so probably better to squash them when merging 