### PR TITLE
feat: add the player name to every log record

### DIFF
--- a/ikabot/helpers/logging.py
+++ b/ikabot/helpers/logging.py
@@ -4,8 +4,23 @@ This module will set up proper ikabot logging when imported.
 
 import logging
 import logging.handlers
+import os
 
 from ikabot.config import LOGS_DIRECTORY_FILE, DEFAULT_LOG_LEVEL
+
+UNKNOWN_PLAYER = "unknown"
+# the name is kept in the environment so that the background tasks inherit it: they are
+# spawned (not forked) on Windows and macOS, which re-imports this module from scratch
+PLAYER_ENV_VAR = "IKABOT_PLAYER"
+
+class PlayerNameFilter(logging.Filter):
+    """Adds the name of the logged in player to every record, so that logs written by
+    several accounts running at the same time can be told apart. The name is unknown
+    until the login finishes, so records written before that are marked as such"""
+
+    def filter(self, record):
+        record.player = os.environ.get(PLAYER_ENV_VAR) or UNKNOWN_PLAYER
+        return True
 
 # TODO wrap logging functions to remove cookies from logs, or add a filter
 class IkabotLogger(logging.Logger):
@@ -19,8 +34,9 @@ rotatingFileHandler = logging.handlers.RotatingFileHandler(
                 maxBytes=10 * 1024 * 1024, #max logfile size is 10 MB
                 backupCount=10, # max number of log files is 10
                     )
+rotatingFileHandler.addFilter(PlayerNameFilter())
 logConfig = {
-    'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    'format': '%(asctime)s - %(player)s - %(name)s - %(levelname)s - %(message)s',
     'level': DEFAULT_LOG_LEVEL,
     'force': True,
     'handlers': [rotatingFileHandler]
@@ -35,3 +51,13 @@ for name in logging.root.manager.loggerDict:
 def getLogger(name: str) -> IkabotLogger:
     """Convenience function to get a logger by name"""
     return logging.getLogger(name)
+
+def setLoggedInPlayer(username: str) -> None:
+    """Sets the player name that will be written in every log record from now on, in this
+    process and in every background task started after this call
+    Parameters
+    ----------
+    username : str
+        name of the logged in player
+    """
+    os.environ[PLAYER_ENV_VAR] = username if username else UNKNOWN_PLAYER

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from ikabot.helpers.logging import getLogger
+from ikabot.helpers.logging import getLogger, setLoggedInPlayer
 import base64
 import datetime
 import getpass
@@ -863,6 +863,7 @@ class Session:
             config.infoUser = "Server:{}".format(self.servidor)
             config.infoUser += ", World:{}".format(self.word)
             config.infoUser += ", Player:{}".format(self.username)
+            setLoggedInPlayer(self.username)
             banner()
 
         self.host = "s{}-{}.ikariam.gameforge.com".format(self.mundo, self.servidor)

--- a/tests/ikabot/helpers/test_logging.py
+++ b/tests/ikabot/helpers/test_logging.py
@@ -1,0 +1,93 @@
+import unittest
+import logging
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+from ikabot.helpers.logging import (
+    PLAYER_ENV_VAR,
+    PlayerNameFilter,
+    UNKNOWN_PLAYER,
+    setLoggedInPlayer,
+)
+
+
+class TestPlayerNameFilter(unittest.TestCase):
+    """Test that the player name is added to every log record"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        os.environ.pop(PLAYER_ENV_VAR, None)
+        self.filter = PlayerNameFilter()
+        self.record = logging.LogRecord(
+            name='ikabot.test',
+            level=logging.ERROR,
+            pathname=__file__,
+            lineno=1,
+            msg='something broke',
+            args=None,
+            exc_info=None,
+        )
+
+    def tearDown(self):
+        """Leave the environment as the tests found it"""
+        os.environ.pop(PLAYER_ENV_VAR, None)
+
+    def test_player_is_unknown_before_login(self):
+        """Records written before the login are marked as unknown"""
+        self.filter.filter(self.record)
+
+        self.assertEqual(self.record.player, UNKNOWN_PLAYER)
+
+    def test_player_is_added_after_login(self):
+        """Once the player is set, it is added to the record"""
+        setLoggedInPlayer('Herakles69')
+
+        self.filter.filter(self.record)
+
+        self.assertEqual(self.record.player, 'Herakles69')
+
+    def test_filter_never_drops_records(self):
+        """The filter only adds information, it must not filter anything out"""
+        self.assertTrue(self.filter.filter(self.record))
+
+    def test_empty_player_falls_back_to_unknown(self):
+        """An empty or missing name must not leave the field blank"""
+        setLoggedInPlayer('Herakles69')
+        setLoggedInPlayer(None)
+
+        self.filter.filter(self.record)
+
+        self.assertEqual(self.record.player, UNKNOWN_PLAYER)
+
+    def test_name_is_published_to_the_environment(self):
+        """Background tasks are spawned, so they only inherit the name through the
+        environment"""
+        setLoggedInPlayer('Herakles69')
+
+        self.assertEqual(os.environ[PLAYER_ENV_VAR], 'Herakles69')
+
+    def test_name_is_read_from_the_environment(self):
+        """A spawned task picks up the name set by the parent before it started"""
+        os.environ[PLAYER_ENV_VAR] = 'InheritedName'
+
+        self.filter.filter(self.record)
+
+        self.assertEqual(self.record.player, 'InheritedName')
+
+    def test_record_is_formatted_with_the_player_name(self):
+        """The name shows up in the formatted line"""
+        setLoggedInPlayer('Herakles69')
+        formatter = logging.Formatter(
+            '%(asctime)s - %(player)s - %(name)s - %(levelname)s - %(message)s'
+        )
+
+        self.filter.filter(self.record)
+        line = formatter.format(self.record)
+
+        self.assertIn(' - Herakles69 - ikabot.test - ERROR - something broke', line)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

When several accounts are run at the same time they all write to the same log
file and there is no way to tell which instance produced a given line.

## Change

The player name is added to the log format:

2026-08-21 13:13:02,094 - JohnWick - ikabot.web.session - INFO - __checkCookie()
2026-08-21 13:13:02,097 - JohnWick - urllib3.connectionpool - DEBUG - Resetting dropped connection: ...

It is injected by a `logging.Filter` on the file handler, so no call site has to
change and records coming from libraries (urllib3, requests) get the name too.
Records written before the login finishes are marked as `unknown`, since at that
point the account genuinely is not known yet.

## Why an environment variable

The filter reads the name from `IKABOT_PLAYER` rather than from module state.
This is the part that took a second attempt to get right, so it is worth
explaining.

Every feature runs in a `multiprocessing.Process` and on Windows and macOS
those children are **spawned**, not forked: the child re-imports the modules
from scratch and loses anything held in module state. My first attempt set the
name again in `set_child_mode()`, but only 23 of the 44 feature modules call it
(`getStatus`, for one, does not), and even in those that do, the whole
interactive phase runs before the call. In practice almost every line was still
`unknown`.

The environment is inherited by spawned and forked children alike, so the name
is correct in every feature from its first line, with no per-feature opt-in.

## Tests

`tests/ikabot/helpers/test_logging.py` covers: unknown before login, the name
after login, the filter never dropping records, an empty name falling back to
`unknown`, publishing to and reading from the environment, and the formatted
line.

Also tested in game with a real account, checking that the name appears on
records written from spawned child processes and from third-party libraries.

Closes #322