### PR TITLE
feat: show pirate fortress points in the account status

### DIFF
--- a/ikabot/function/autoPirate.py
+++ b/ikabot/function/autoPirate.py
@@ -398,6 +398,54 @@ def getPiracyCities(session, pirateMissionChoice):
     return piracyCities
 
 
+def getPirateFortressHtml(session, cityId):
+    """Gets the crew tab of the pirate fortress. The fortress always sits on position 17
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    cityId : int
+        id of a city which has a pirate fortress in it
+
+    Returns
+    -------
+    html : str
+    """
+    params = {
+        "view": "pirateFortress",
+        "activeTab": "tabCrew",
+        "cityId": cityId,
+        "position": 17,
+        "backgroundView": "city",
+        "currentCityId": cityId,
+        "templateView": "pirateFortress",
+        "actionRequest": actionRequest,
+        "ajax": 1,
+    }
+    return session.post(params=params)
+
+
+def getPirateFortressPoints(session, cityId):
+    """Gets the capture points and the crew strength of the account. Both are shared by
+    every city, so any city with a pirate fortress can be used to read them
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    cityId : int
+        id of a city which has a pirate fortress in it
+
+    Returns
+    -------
+    (capturePoints, crewPoints) : tuple
+        None if the fortress did not report them
+    """
+    html = getPirateFortressHtml(session, cityId)
+    capturePoints = re.search(r'\\"capturePoints\\":\\"(\d+)\\"', html)
+    crewPoints = re.search(r'\\"crewPoints\\":\\"(\d+)\\"', html)
+    if capturePoints is None or crewPoints is None:
+        return None
+    return int(capturePoints.group(1)), int(crewPoints.group(1))
+
+
 def convertCapturePoints(session, piracyCities, convertPerMission):
     """Converts all the users capture points into crew strength
     Parameters
@@ -405,18 +453,7 @@ def convertCapturePoints(session, piracyCities, convertPerMission):
     session : ikabot.web.session.Session
     piracyCities: a list containing all cities which have a pirate fortress
     """
-    params = {
-        "view": "pirateFortress",
-        "activeTab": "tabCrew",
-        "cityId": piracyCities[0]["id"],
-        "position": 17,
-        "backgroundView": "city",
-        "currentCityId": piracyCities[0]["id"],
-        "templateView": "pirateFortress",
-        "actionRequest": actionRequest,
-        "ajax": 1,
-    }
-    html = session.post(params=params)
+    html = getPirateFortressHtml(session, piracyCities[0]["id"])
     rta = re.search(r'\\"capturePoints\\":\\"(\d+)\\"', html)
     capturePoints = int(rta.group(1))
     if convertPerMission == "all":

--- a/ikabot/function/autoPirate.py
+++ b/ikabot/function/autoPirate.py
@@ -435,15 +435,17 @@ def getPirateFortressPoints(session, cityId):
 
     Returns
     -------
-    (capturePoints, crewPoints) : tuple
+    (capturePoints, crewStrength) : tuple
         None if the fortress did not report them
     """
     html = getPirateFortressHtml(session, cityId)
     capturePoints = re.search(r'\\"capturePoints\\":\\"(\d+)\\"', html)
-    crewPoints = re.search(r'\\"crewPoints\\":\\"(\d+)\\"', html)
-    if capturePoints is None or crewPoints is None:
+    # crewPoints only counts the crew converted from capture points, the strength the
+    # game shows also includes the basic and the bonus crew
+    crewStrength = re.search(r'\\"completeCrewPoints\\":(\d+)', html)
+    if capturePoints is None or crewStrength is None:
         return None
-    return int(capturePoints.group(1)), int(crewPoints.group(1))
+    return int(capturePoints.group(1)), int(crewStrength.group(1))
 
 
 def convertCapturePoints(session, piracyCities, convertPerMission):

--- a/ikabot/function/getStatus.py
+++ b/ikabot/function/getStatus.py
@@ -6,6 +6,7 @@ import re
 from decimal import *
 
 from ikabot.config import *
+from ikabot.function.autoPirate import getPirateFortressPoints
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.market import getGold
@@ -49,13 +50,20 @@ def getStatus(session, event, stdin_fd, predetermined_input):
         total_citizens = 0
         available_ships = 0
         total_ships = 0
+        pirate_city_id = None
         for id in ids:
-            session.get("view=city&cityId={}".format(id), noIndex=True)
+            html = session.get("view=city&cityId={}".format(id), noIndex=True)
             data = session.get("view=updateGlobalData&ajax=1", noIndex=True)
             json_data = json.loads(data, strict=False)
             json_data = json_data[0][1]["headerData"]
             if json_data["relatedCity"]["owncity"] != 1:
                 continue
+            # the points belong to the account, so the first fortress found is enough
+            if pirate_city_id is None:
+                for building in getCity(html)["position"]:
+                    if building["building"] == "pirateFortress":
+                        pirate_city_id = id
+                        break
             wood = Decimal(json_data["resourceProduction"])
             good = Decimal(json_data["tradegoodProduction"])
             typeGood = int(json_data["producedTradegood"])
@@ -85,6 +93,16 @@ def getStatus(session, event, stdin_fd, predetermined_input):
                 )
             )
         print("Ships {:d}/{:d}".format(int(available_ships), int(total_ships)))
+        if pirate_city_id is not None:
+            points = getPirateFortressPoints(session, pirate_city_id)
+            if points is not None:
+                (capture_points, crew_points) = points
+                print(
+                    "Pirate fortress: {} capture points, {} crew strength".format(
+                        addThousandSeparator(capture_points),
+                        addThousandSeparator(crew_points),
+                    )
+                )
         print("\nTotal:")
         print("{:>10}".format(" "), end="|")
         for i in range(len(materials_names)):

--- a/tests/ikabot/function/test_autoPirate.py
+++ b/tests/ikabot/function/test_autoPirate.py
@@ -28,13 +28,22 @@ class TestGetPirateFortressPoints(unittest.TestCase):
 
     def test_points_are_read_from_the_fortress(self):
         """Both numbers come from the same response"""
-        self.assertEqual(getPirateFortressPoints(self.session, 12345), (80169, 18407))
+        self.assertEqual(getPirateFortressPoints(self.session, 12345), (80169, 19843))
 
-    def test_crew_points_are_not_confused_with_the_other_crew_fields(self):
-        """basicCrewPoints, bonusCrewPoints and completeCrewPoints all end in crewPoints"""
-        (__, crew_points) = getPirateFortressPoints(self.session, 12345)
+    def test_crew_strength_includes_the_basic_and_the_bonus_crew(self):
+        """crewPoints is only the crew converted from capture points, the strength the
+        game shows is completeCrewPoints (18407 + 36 + 1400)"""
+        (__, crew_strength) = getPirateFortressPoints(self.session, 12345)
 
-        self.assertEqual(crew_points, 18407)
+        self.assertEqual(crew_strength, 19843)
+
+    def test_crew_strength_is_read_with_no_capture_points(self):
+        """A player who never converted has crewPoints 0 but still has crew strength"""
+        self.session.post.return_value = FORTRESS_RESPONSE.replace(
+            '\\"crewPoints\\":\\"18407\\"', '\\"crewPoints\\":\\"0\\"'
+        ).replace('\\"completeCrewPoints\\":19843', '\\"completeCrewPoints\\":128')
+
+        self.assertEqual(getPirateFortressPoints(self.session, 12345), (80169, 128))
 
     def test_the_fortress_is_asked_for_the_given_city(self):
         """Any city with a fortress reports the same points, the fortress is on position 17"""

--- a/tests/ikabot/function/test_autoPirate.py
+++ b/tests/ikabot/function/test_autoPirate.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import Mock
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+from ikabot.function.autoPirate import getPirateFortressPoints
+
+# the fortress reports its state in the params of the updateTemplateData object, this is
+# the shape of that response
+FORTRESS_RESPONSE = (
+    '[[["updateTemplateData",{"filepath":"//gf2.geo.gfsrv.net/cdna0/7254428.js",'
+    '"params":"{\\"serverTime\\":1684007856,\\"view\\":\\"pirateFortress\\",'
+    '\\"position\\":17,\\"buildingLevel\\":15,\\"capturePoints\\":\\"80169\\",'
+    '\\"crewPoints\\":\\"18407\\",\\"basicCrewPoints\\":36,\\"bonusCrewPoints\\":1400,'
+    '\\"completeCrewPoints\\":19843,\\"crewConversionFactor\\":10}"}]]]'
+)
+
+
+class TestGetPirateFortressPoints(unittest.TestCase):
+    """Test reading the capture points and the crew strength of the account"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.session = Mock()
+        self.session.post.return_value = FORTRESS_RESPONSE
+
+    def test_points_are_read_from_the_fortress(self):
+        """Both numbers come from the same response"""
+        self.assertEqual(getPirateFortressPoints(self.session, 12345), (80169, 18407))
+
+    def test_crew_points_are_not_confused_with_the_other_crew_fields(self):
+        """basicCrewPoints, bonusCrewPoints and completeCrewPoints all end in crewPoints"""
+        (__, crew_points) = getPirateFortressPoints(self.session, 12345)
+
+        self.assertEqual(crew_points, 18407)
+
+    def test_the_fortress_is_asked_for_the_given_city(self):
+        """Any city with a fortress reports the same points, the fortress is on position 17"""
+        getPirateFortressPoints(self.session, 12345)
+
+        params = self.session.post.call_args.kwargs["params"]
+        self.assertEqual(params["cityId"], 12345)
+        self.assertEqual(params["currentCityId"], 12345)
+        self.assertEqual(params["position"], 17)
+        self.assertEqual(params["view"], "pirateFortress")
+
+    def test_missing_points_are_reported_as_none(self):
+        """A response without the points must not be shown as zero"""
+        self.session.post.return_value = '[[["updateTemplateData",{"params":"{}"}]]]'
+
+        self.assertIsNone(getPirateFortressPoints(self.session, 12345))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #85 and also #136 which was closed as a duplicate of it back in 2023 but never actually implemented.

## Problem

The capture points are already being read by `convertCapturePoints()` to work out how much crew to convert, but the number is used and thrown away. Nothing in the bot ever shows it. If you want to know where your pirate fortress stands you have to log into the game and go look.

## Change

Account status now prints one extra line, right under the ships:

Ships 323/323
Pirate fortress: 0 capture points, 128 crew strength

Both numbers belong to the account rather than to a city, which is why `convertCapturePoints()` has always just used `piracyCities[0]`, so the first fortress found is enough and there is nothing to add up.

It costs one extra request. The status loop already asks for `view=city&cityId=...` on every city to switch the active city and then throws the response away without reading it. That response is the city html, so spotting the fortress is free. The only new request is the one to the fortress itself and it only happens for players who have one.

I pulled the request out of `convertCapturePoints()` into `getPirateFortressHtml()` so both readers share it. The params are identical, the only change is that the city id comes in as an argument instead of being read from `piracyCities[0]`.

## Where the field names came from

@ninichuuh posted the full response dump in #85 back in 2023. That is where the field names come from and posting the whole thing rather than just the one field turned out to matter:

"capturePoints":"80169", "crewPoints":"18407", "basicCrewPoints":36,
"bonusCrewPoints":1400, "completeCrewPoints":19843

`18407 + 36 + 1400 = 19843`. So `crewPoints` is only the crew you converted from capture points and the strength the game actually displays is `completeCrewPoints`. I had it wrong at first and it only showed up when testing on an account that had never converted anything: `crewPoints` was 0 while the game showed 128. Worth knowing if anyone touches this later.

`completeCrewPoints` also comes back as a plain integer, unlike the other two which are quoted strings, so it needs a slightly different regex.

## Tests

`tests/ikabot/function/test_autoPirate.py` builds a fixture from that dump and covers reading both numbers, the crew strength including the basic and bonus crew, the case where a player has no capture points but does have crew, the request going to the right city and position 17 and a response with no points reported returning `None` rather than showing zeros.

Tested in game on a 15 city account: `0 capture points, 128 crew strength`, which matches what the fortress shows in the browser.