### PR TITLE
feat: buy from a specific player or city in the market

### DIFF
--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -22,6 +22,10 @@ from ikabot.helpers.varios import addThousandSeparator, getDateTime
 from ikabot.helpers.pedirInfo import getShipCapacity
 
 
+BUY_FROM_ANYONE = 1
+BUY_FROM_PLAYER = 2
+BUY_FROM_CITY = 3
+
 
 def chooseResource(session, city):
     """
@@ -147,6 +151,44 @@ def chooseCommertialCity(commercial_cities):
     return commercial_cities[selected_city_index - 1]
 
 
+def filterOffers(offers):
+    """Lets the user buy from one specific player or one specific city instead of always
+    taking the cheapest offers. The lowest price is not always the desired one, the user
+    might need to trade with someone in particular
+    Parameters
+    ----------
+    offers : list[dict]
+
+    Returns
+    -------
+    (offers, seller) : tuple
+        the offers that belong to the chosen seller, and its name (None if the user did
+        not choose one)
+    """
+    print("Buy from:")
+    print("({:d}) Anyone in range".format(BUY_FROM_ANYONE))
+    print("({:d}) A specific player".format(BUY_FROM_PLAYER))
+    print("({:d}) A specific city".format(BUY_FROM_CITY))
+    choice = read(min=BUY_FROM_ANYONE, max=BUY_FROM_CITY, default=BUY_FROM_ANYONE)
+    if choice == BUY_FROM_ANYONE:
+        return offers, None
+
+    if choice == BUY_FROM_PLAYER:
+        key = "jugadorAComprar"
+        print("\nWhich player do you want to buy from?\n")
+    else:
+        key = "ciudadDestino"
+        print("\nWhich city do you want to buy from?\n")
+
+    # dict.fromkeys removes the duplicates without losing the order of the offers
+    sellers = list(dict.fromkeys([offer[key] for offer in offers]))
+    for i, seller in enumerate(sellers):
+        print("({:d}) {}".format(i + 1, seller))
+    seller = sellers[read(min=1, max=len(sellers)) - 1]
+
+    return [offer for offer in offers if offer[key] == seller], seller
+
+
 def buyResources(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -189,6 +231,10 @@ def buyResources(session, event, stdin_fd, predetermined_input):
             event.set()
             return
 
+        # let the user buy from one seller only
+        (offers, seller) = filterOffers(offers)
+        banner()
+
         # display offers to the user
         total_price = 0
         total_amount = 0
@@ -196,6 +242,11 @@ def buyResources(session, event, stdin_fd, predetermined_input):
             amount = offer["amountAvailable"]
             price = offer["precio"]
             cost = amount * price
+            print(
+                "seller:{} ({})".format(
+                    offer["jugadorAComprar"], offer["ciudadDestino"]
+                )
+            )
             print("amount:{}".format(addThousandSeparator(amount)))
             print("price :{:d}".format(price))
             print("cost  :{}".format(addThousandSeparator(cost)))
@@ -254,6 +305,8 @@ def buyResources(session, event, stdin_fd, predetermined_input):
     info = "\nI will buy {} from {} to {}\n".format(
         addThousandSeparator(amount_to_buy), materials_names[resource], city["cityName"]
     )
+    if seller is not None:
+        info += "Buying from {} only\n".format(seller)
     setInfoSignal(session, info)
     try:
         do_it(session, city, offers, amount_to_buy)

--- a/tests/ikabot/function/test_buyResources.py
+++ b/tests/ikabot/function/test_buyResources.py
@@ -1,0 +1,107 @@
+import unittest
+from unittest.mock import patch
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+from ikabot.function.buyResources import (
+    BUY_FROM_ANYONE,
+    BUY_FROM_CITY,
+    BUY_FROM_PLAYER,
+    filterOffers,
+)
+
+
+def offer(player, city, amount, price):
+    return {
+        "jugadorAComprar": player,
+        "ciudadDestino": city,
+        "amountAvailable": amount,
+        "precio": price,
+    }
+
+
+class TestFilterOffers(unittest.TestCase):
+    """Test that the user can buy from one seller instead of the cheapest ones"""
+
+    def setUp(self):
+        """The offers arrive sorted by price, as the caller sorts them"""
+        self.offers = [
+            offer("Odysseus", "Ithaca", 1000, 10),
+            offer("Priam", "Troy", 2000, 15),
+            offer("Odysseus", "Same", 3000, 20),
+        ]
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_buying_from_anyone_keeps_every_offer(self, mock_read, mock_print):
+        """The default choice must not change the offers at all"""
+        mock_read.side_effect = [BUY_FROM_ANYONE]
+
+        (offers, seller) = filterOffers(self.offers)
+
+        self.assertEqual(offers, self.offers)
+        self.assertIsNone(seller)
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_buying_from_a_player_keeps_all_of_their_offers(self, mock_read, mock_print):
+        """A player selling from several cities must keep every one of their offers"""
+        mock_read.side_effect = [BUY_FROM_PLAYER, 1]
+
+        (offers, seller) = filterOffers(self.offers)
+
+        self.assertEqual(seller, "Odysseus")
+        self.assertEqual([o["ciudadDestino"] for o in offers], ["Ithaca", "Same"])
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_buying_from_a_city_keeps_only_that_city(self, mock_read, mock_print):
+        """Choosing a city must not bring in the other cities of the same player"""
+        mock_read.side_effect = [BUY_FROM_CITY, 3]
+
+        (offers, seller) = filterOffers(self.offers)
+
+        self.assertEqual(seller, "Same")
+        self.assertEqual(offers, [self.offers[2]])
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_a_player_is_listed_once(self, mock_read, mock_print):
+        """A player with several offers must not be listed several times"""
+        mock_read.side_effect = [BUY_FROM_PLAYER, 2]
+
+        (offers, seller) = filterOffers(self.offers)
+
+        self.assertEqual(seller, "Priam")
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_sellers_are_listed_by_ascending_price(self, mock_read, mock_print):
+        """The list must follow the order of the offers, which is sorted by price"""
+        mock_read.side_effect = [BUY_FROM_PLAYER, 1]
+
+        filterOffers(self.offers)
+
+        listed = [str(c) for c in mock_print.call_args_list]
+        self.assertLess(
+            next(i for i, line in enumerate(listed) if "Odysseus" in line),
+            next(i for i, line in enumerate(listed) if "Priam" in line),
+        )
+
+    @patch('ikabot.function.buyResources.print')
+    @patch('ikabot.function.buyResources.read')
+    def test_the_offers_are_never_emptied(self, mock_read, mock_print):
+        """The seller is picked from the offers themselves, so there is always a match"""
+        for choice in (BUY_FROM_PLAYER, BUY_FROM_CITY):
+            mock_read.side_effect = [choice, 1]
+
+            (offers, seller) = filterOffers(self.offers)
+
+            self.assertTrue(len(offers) > 0)
+            self.assertIsNotNone(seller)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #312.

## Problem

Buying from the market always works down the list from the cheapest offer up. As the issue puts it, "lowest isn't always what we want". Sometimes you need the resources to come from a particular player or city even if you end up paying more for them.

The offer screen doesn't even tell you who's selling. It prints the amount, the price and the cost and that's it.

## Change

After you pick the resource there's one extra question:

Buy from:
(1) Anyone in range
(2) A specific player
(3) A specific city

Pick 2 or 3 and it lists whoever is selling and you choose by number. Enter keeps the old behaviour.

The offers now show the seller as well:

seller:Odysseus (Ithaca)
amount:12.000
price :23
cost  :276.000

This turned out cheap to do because `getOffers()` was already pulling `jugadorAComprar` and `ciudadDestino` out of the market html for every offer. The data was sitting there and nothing was ever done with it. The filter just hands back a shorter list of the same shape, so the totals, `calculateCost()` and `do_it()` didn't need touching at all.

Couple of details worth mentioning:

The seller list is built from the offers themselves using `dict.fromkeys`, so someone selling from three cities shows up once instead of three times, and the list stays in price order because that's the order the offers come in. Pick that player and you get all three of their offers.

There's no empty case to deal with. You're choosing from names that came out of the offer list, so there's always at least one match left afterwards. I put a test on that in case someone changes it later.

If you do filter, the process description mentions it, so you can tell two background buys apart in the task table.

## What's not in here

Selling. `sellResources.py` has its own `getOffers()` and it returns tuples rather than dicts, so sharing the filter would mean either writing it twice or passing keys and indices around, and neither felt worth it. The issue says buying from a specific person is the priority so I left selling alone. Happy to do it as a follow up if people want it.

## Tests

`tests/ikabot/function/test_buyResources.py`, six of them: the default leaves the offers untouched, picking a player keeps all of their cities, picking a city doesn't drag in that player's other cities, a player selling several times is only listed once, the list follows price order, and the filter never empties the list.

Tested in game.