### PR TITLE
feat: assign temple priests from the Set Workers menu

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -54,7 +54,7 @@ from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.process import updateProcessList
 from ikabot.web.session import *
 from ikabot.function.UpgradeUnits import UpgradeUnits
-from ikabot.function.modifyProduction import modifyProduction, modifyAcademyWorkers
+from ikabot.function.modifyProduction import modifyProduction, modifyAcademyWorkers, modifyTempleWorkers
 from ikabot.function.reorganizeCityBuildings import reorganizeCityBuildings
 from ikabot.function.UpgradeUnits import UpgradeUnits
 from ikabot.function.developer import developer
@@ -166,6 +166,7 @@ def menu(session, checkUpdate=True):
         2301: modifyProduction,
         2302: modifyAcademyWorkers,
         2303: tavernManager,
+        2304: modifyTempleWorkers,
         24: reorganizeCityBuildings,
     }
 
@@ -192,7 +193,7 @@ def menu(session, checkUpdate=True):
     print("(20) Dump / Monitor world")
     print("(21) Options / Settings")
     print("(22) Consolidate resources")
-    print("(23) Set Workers(Production-Academy-Tavern)")
+    print("(23) Set Workers(Production-Academy-Tavern-Temple)")
     print("(24) Reorganize city buildings")
 
     total_options = len(menu_actions) + 1
@@ -275,8 +276,9 @@ def menu(session, checkUpdate=True):
         print("(1) Production")
         print("(2) Academy")
         print("(3) Tavern")
+        print("(4) Temple")
 
-        selected = read(min=0, max=3, digit=True)
+        selected = read(min=0, max=4, digit=True)
         if selected == 0:
             menu(session)
             return

--- a/ikabot/function/modifyProduction.py
+++ b/ikabot/function/modifyProduction.py
@@ -177,3 +177,64 @@ def modifyAcademyWorkers(session, event, stdin_fd, predetermined_input):
     except KeyboardInterrupt:
         return
     event.set()
+
+
+def modifyTempleWorkers(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    sys.stdin = os.fdopen(stdin_fd)
+    config.predetermined_input = predetermined_input
+    try:
+        banner()
+        city_ids, _ = ignoreCities(session, msg="In which cities do you want to set priests?")
+
+        print("What % of priests do you want to use? (Default 100%)")
+        percentageWorkers = read(min=0, max=100, default=100)
+
+        banner()
+        for city_id in city_ids:
+            html = session.get(city_url + city_id)
+            city = getCity(html)
+
+            temple_slot = next(
+                (slot for slot in city['position'] if slot.get('building') == 'temple'),
+                None
+            )
+            if temple_slot is None:
+                print(f"No temple in {city['name']}, skipping.")
+                continue
+
+            position = temple_slot['position']
+            url = f"view=temple&cityId={city['id']}&position={position}&backgroundView=city&currentCityId={city['id']}&actionRequest={actionRequest}&ajax=1"
+            resp = session.post(url)
+            resp_json = json.loads(resp, strict=False)
+            max_priests = resp_json[2][1]['js_TempleSlider']['slider']['max_value']
+
+            if percentageWorkers == 100:
+                finalPriests = max_priests
+            else:
+                finalPriests = int(max_priests / 100 * percentageWorkers)
+
+            session.post(params={
+                "action": "CityScreen", "function": "assignPriests",
+                "cityId": city["id"], "position": position,
+                "priests": finalPriests,
+                "backgroundView": "city", "currentCityId": city["id"],
+                "templateView": "temple", "actionRequest": actionRequest, "ajax": "1"
+            })
+            print(f"{finalPriests} priests set for Temple in {city['name']}.")
+
+            wait(3, 4)
+
+        print("\nAll temples have been set!")
+        enter()
+
+    except KeyboardInterrupt:
+        return
+    event.set()

--- a/tests/ikabot/function/test_modifyProduction.py
+++ b/tests/ikabot/function/test_modifyProduction.py
@@ -1,0 +1,118 @@
+import unittest
+from unittest.mock import Mock, patch
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../../')))
+
+from ikabot.function.modifyProduction import modifyTempleWorkers
+
+# the temple reports the priests in js_TempleSlider, the same place the academy reports
+# the scientists in js_AcademySlider
+TEMPLE_RESPONSE = (
+    '[["changeView",["temple",""]],["updateGlobalData",{}],["updateTemplateData",'
+    '{"js_TempleSlider":{"slider":{"id":"slider_temple","max_value":943,'
+    '"overcharge":false,"ini_value":600,"textfield":"inputPriests",'
+    '"callback_data":{"citizens_per_priest":5}}}}]]'
+)
+
+
+def city(name, position):
+    """A city whose temple sits on the given position, plus a building that is not one"""
+    return {
+        "id": "30823",
+        "name": name,
+        "position": [
+            {"position": 0, "building": "townHall"},
+            {"position": position, "building": "temple"},
+        ],
+    }
+
+
+def cityWithoutTemple(name):
+    return {"id": "40000", "name": name, "position": [{"position": 0, "building": "townHall"}]}
+
+
+def assignCalls(session):
+    """The POSTs that assign the priests, the other POST reads the temple view"""
+    return [
+        call.kwargs["params"]
+        for call in session.post.call_args_list
+        if call.kwargs.get("params") is not None
+    ]
+
+
+class TestModifyTempleWorkers(unittest.TestCase):
+    """Test assigning the priests of the temple city by city"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.session = Mock()
+        self.session.post.return_value = TEMPLE_RESPONSE
+
+    def run_with(self, cities, percentage):
+        """Runs the feature over the given cities answering the percentage prompt"""
+        event = Mock()
+        with patch('ikabot.function.modifyProduction.ignoreCities',
+                   return_value=([c["id"] for c in cities], None)), \
+             patch('ikabot.function.modifyProduction.getCity', side_effect=cities), \
+             patch('ikabot.function.modifyProduction.read', return_value=percentage), \
+             patch('ikabot.function.modifyProduction.wait'), \
+             patch('ikabot.function.modifyProduction.banner'), \
+             patch('ikabot.function.modifyProduction.enter'), \
+             patch('ikabot.function.modifyProduction.os.fdopen'), \
+             patch('builtins.print'):
+            modifyTempleWorkers(self.session, event, 0, [])
+        return event
+
+    def test_full_percentage_uses_the_maximum_of_the_slider(self):
+        """100% must send the max_value the temple reports, not the current value"""
+        self.run_with([city("Crowcifix", 23)], 100)
+
+        self.assertEqual(assignCalls(self.session)[0]["priests"], 943)
+
+    def test_a_percentage_is_taken_from_the_maximum(self):
+        """50% of 943 truncates to 471"""
+        self.run_with([city("Crowcifix", 23)], 50)
+
+        self.assertEqual(assignCalls(self.session)[0]["priests"], 471)
+
+    def test_zero_percent_empties_the_temple(self):
+        """0% is a valid choice, it sends the citizens back to work"""
+        self.run_with([city("Crowcifix", 23)], 0)
+
+        self.assertEqual(assignCalls(self.session)[0]["priests"], 0)
+
+    def test_the_temple_position_of_the_city_is_used(self):
+        """The temple is not always on the same plot, so the position comes from the city"""
+        self.run_with([city("Crowcifix", 7)], 100)
+
+        self.assertEqual(assignCalls(self.session)[0]["position"], 7)
+
+    def test_the_priests_are_assigned_through_the_city_screen(self):
+        """The temple uses CityScreen/assignPriests, unlike the academy which uses
+        IslandScreen/workerPlan"""
+        self.run_with([city("Crowcifix", 23)], 100)
+
+        params = assignCalls(self.session)[0]
+        self.assertEqual(params["action"], "CityScreen")
+        self.assertEqual(params["function"], "assignPriests")
+        self.assertEqual(params["cityId"], "30823")
+
+    def test_a_city_without_a_temple_is_skipped(self):
+        """Nothing must be assigned for a city that has no temple"""
+        self.run_with([cityWithoutTemple("Nowhere")], 100)
+
+        self.assertEqual(assignCalls(self.session), [])
+
+    def test_a_city_without_a_temple_does_not_stop_the_others(self):
+        """The cities after the one that is skipped must still be set"""
+        self.run_with([cityWithoutTemple("Nowhere"), city("Crowcifix", 23)], 100)
+
+        assigned = assignCalls(self.session)
+        self.assertEqual(len(assigned), 1)
+        self.assertEqual(assigned[0]["cityId"], "30823")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

The Set Workers menu covers Production, Academy and Tavern. The temple is the one worker slot left out, so priests are still the thing you have to click through city by city in the browser.

## Change

A fourth entry in the submenu:

```
(0) Back
(1) Production
(2) Academy
(3) Tavern
(4) Temple
```

It works the same way the Academy one does. Pick the cities, give it a percentage and it sets the priests in each of them. A city with no temple gets skipped with a note and the rest carry on.


 ## Tests
                                                                                                                                                 

Tested in game. 50% on a temple with a maximum of 943 gave 471 priests and the game agreed.