### PR TITLE
fix: capture Telegram chat id instead of user id for notifications

### DIFF
--- a/ikabot/helpers/botComm.py
+++ b/ikabot/helpers/botComm.py
@@ -315,7 +315,7 @@ def updateTelegramData(session, event=None, stdin_fd=None, predetermined_input=[
                 if "message" in update:
                     if "text" in update["message"]:
                         if update["message"]["text"].strip() == f"/ikabot {rand}":
-                            user_id = update["message"]["from"]["id"]
+                            user_id = update["message"]["chat"]["id"]
                             break
             time.sleep(2)
             print(" " * 100, end="\r")


### PR DESCRIPTION
Use the chat id (which works for both private chats and groups) instead of the sender's user id when capturing the Telegram destination during setup. This allows ikabot to send notifications to a group instead of only to a single private user.