### PR TITLE
Fix cumulative timing drift in attack alerts

### DIFF
--- a/ikabot/function/alertAttacks.py
+++ b/ikabot/function/alertAttacks.py
@@ -67,7 +67,7 @@ def respondToAttack(session):
 
     # this allows the user to respond to an attack via telegram
     while True:
-        time.sleep(60 * 3)
+        start_time = time.time()
         responses = getUserResponse(session)
         for response in responses:
             # the response should be in the form of:
@@ -90,6 +90,9 @@ def respondToAttack(session):
             else:
                 sendToBot(session, "Invalid command: {:d}".format(action))
 
+        elapsed = time.time() - start_time
+        time.sleep(max(0, 60 * 3 - elapsed))
+
 
 def do_it(session, minutes):
     """
@@ -105,6 +108,7 @@ def do_it(session, minutes):
 
     knownAttacks = []
     while True:
+        start_time = time.time()
         ##Catch errors inside the function to not exit for any reason.
         currentAttacks = []
         try:
@@ -162,4 +166,5 @@ def do_it(session, minutes):
             if event_id not in currentAttacks:
                 knownAttacks.remove(event_id)
 
-        time.sleep(minutes * 60)
+        elapsed = time.time() - start_time
+        time.sleep(max(0, minutes * 60 - elapsed))


### PR DESCRIPTION
The polling loop slept a fixed 3 minutes after processing each cycle, so the time spent on HTTP requests and Telegram sends was added on top, accumulating drift that delayed the attack alerts