### PR TITLE
Rework session storage (.ikabot dir instead of file, hotswapping)

### DIFF
--- a/.github/workflows/test_and_run.yml
+++ b/.github/workflows/test_and_run.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout
@@ -44,5 +44,5 @@ jobs:
         python -m pytest tests/ikabot
     - name: Run ikabot
       run: |
-        printf "\n\n" | python -m ikabot &> log.log || cat log.log
+        printf "\n\n\n" | python -m ikabot &> log.log || cat log.log
         grep "Obtaining new blackbox token, please wait..." log.log && exit 0 || exit 1

--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -52,6 +52,7 @@ from ikabot.function.testDiscordBot import testDiscordBot
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.process import updateProcessList
+from ikabot.helpers.sessionStorage import init_storage
 from ikabot.web.session import *
 from ikabot.function.UpgradeUnits import UpgradeUnits
 from ikabot.function.modifyProduction import modifyProduction, modifyAcademyWorkers, modifyTempleWorkers
@@ -405,9 +406,7 @@ def menu(session, checkUpdate=True):
 def init():
     home = "USERPROFILE" if isWindows else "HOME"
     os.chdir(os.getenv(home))
-    if not os.path.isfile(ikaFile):
-        open(ikaFile, "w")
-        os.chmod(ikaFile, 0o600)
+    init_storage()
 
 
 def start():

--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -72,6 +72,7 @@ has_params = False
 menu_cities = ""
 infoUser = ""
 ikaFile = ".ikabot"
+ikaDir = ".ikabot"
 city_url = "view=city&cityId="
 island_url = "view=island&islandId="
 prompt = " >>  "

--- a/ikabot/helpers/aesCipher.py
+++ b/ikabot/helpers/aesCipher.py
@@ -57,18 +57,8 @@ class AESCipher:
         ----------
         session : ikabot.web.session.Session
         """
-        entry_key = self.getEntryKey(session)
-        with open(ikaFile, "r") as filehandler:
-            data = filehandler.read()
-
-        newFile = ""
-        for line in data.split("\n"):
-            if entry_key != line[:64]:
-                newFile += line + "\n"
-
-        with open(ikaFile, "w") as filehandler:
-            filehandler.write(newFile.strip())
-            filehandler.flush()
+        from ikabot.helpers.sessionStorage import delete_session_data
+        delete_session_data(session)
 
     def getSessionData(self, session, all=False):
         """
@@ -77,44 +67,8 @@ class AESCipher:
         session : ikabot.web.session.Session
         all : bool
         """
-        entry_key = self.getEntryKey(session)
-        with open(ikaFile, "r") as filehandler:
-            ciphertexts = filehandler.read()
-
-        for ciphertext in ciphertexts.split("\n"):
-            if entry_key == ciphertext[:64]:
-                ciphertext = ciphertext[64:]
-                try:
-                    plaintext = self.decrypt(ciphertext)
-                except Exception:
-                    msg = "Error while decrypting session data.\nYou may have entered a wrong password."
-                    
-                    if session.padre:
-                        print(msg)
-                    else:
-                        sendToBot(session, msg)
-                    print("\nWould you like to delete the ikabot session data associated with this email address? [y/N]")
-                    rta = read(values=["n", "N", "y", "Y"])
-                    if rta.lower() == "n":
-                        os._exit(0)
-                    self.deleteSessionData(session)
-                    os._exit(0)
-                data_dict = json.loads(plaintext, strict=False)
-                if all:
-                    return data_dict
-                else:
-                    try:
-                        try:
-                            session_data = data_dict[session.username][session.mundo][
-                                session.servidor
-                            ]
-                        except Exception:
-                            session_data = {}
-                        session_data["shared"] = data_dict["shared"]
-                        return session_data
-                    except KeyError:
-                        return {}
-        return {}
+        from ikabot.helpers.sessionStorage import get_session_data
+        return get_session_data(session, all_data=all)
 
     def setSessionData(self, session, data, shared=False):
         """
@@ -123,39 +77,6 @@ class AESCipher:
         session : ikabot.web.session.Session
         data : dict
         """
-        session_data = self.getSessionData(session, True)
+        from ikabot.helpers.sessionStorage import set_session_data
+        set_session_data(session, data, shared=shared)
 
-        if shared:
-            if "shared" not in session_data:
-                session_data["shared"] = {}
-            if "logLevel" not in session_data["shared"]:
-                session_data["shared"]["logLevel"] = 2  # Warn by default
-            session_data["shared"] = {**session_data["shared"], **data}
-        else:
-            if session.username not in session_data:
-                session_data[session.username] = {}
-            if session.mundo not in session_data[session.username]:
-                session_data[session.username][session.mundo] = {}
-            if session.servidor not in session_data[session.username][session.mundo]:
-                session_data[session.username][session.mundo][session.servidor] = {}
-            if "shared" not in session_data:
-                session_data["shared"] = {}
-            session_data[session.username][session.mundo][session.servidor] = data
-
-        plaintext = json.dumps(session_data)
-        ciphertext = self.encrypt(plaintext)
-
-        with open(ikaFile, "r") as filehandler:
-            data = filehandler.read()
-
-        entry_key = self.getEntryKey(session)
-        newFile = ""
-        newline = entry_key + " " + ciphertext
-        for line in data.split("\n"):
-            if entry_key != line[:64]:
-                newFile += line + "\n"
-        newFile += newline + "\n"
-
-        with open(ikaFile, "w") as filehandler:
-            filehandler.write(newFile.strip())
-            filehandler.flush()

--- a/ikabot/helpers/sessionStorage.py
+++ b/ikabot/helpers/sessionStorage.py
@@ -62,6 +62,64 @@ def get_user_file_path(email):
     return os.path.join(get_users_dir(), filename)
 
 
+def get_saved_users():
+    """Returns the list of saved user accounts (their emails) found in ~/.ikabot/users,
+    excluding the default account used for empty mail."""
+    users_dir = get_users_dir()
+    if not os.path.isdir(users_dir):
+        return []
+
+    saved = []
+    for filename in sorted(os.listdir(users_dir)):
+        if not filename.endswith(".json"):
+            continue
+        if filename == f"{sanitize_email('')}.json":
+            continue
+        filepath = os.path.join(users_dir, filename)
+        data = read_json_file(filepath, {})
+        email = data.get("email") or filename[: -len(".json")]
+        saved.append(email)
+    return saved
+
+
+def find_user_file_for_email(email):
+    """
+    Resolves an email to its session JSON file(s) in ~/.ikabot/users.
+
+    Returns a tuple (matching_path, duplicados):
+      - matching_path: path of the most recently modified matching file,
+                       or None if no user file matches the email.
+      - duplicados:    True if more than one file matches the email.
+    The default_user file (empty mail) is never considered a match.
+    """
+    users_dir = get_users_dir()
+    if not os.path.isdir(users_dir):
+        return None, False
+
+    candidates = []
+    for filename in os.listdir(users_dir):
+        if not filename.endswith(".json"):
+            continue
+        if filename == f"{sanitize_email('')}.json":
+            continue
+        filepath = os.path.join(users_dir, filename)
+        data = read_json_file(filepath, {})
+        stored_email = data.get("email") or filename[: -len(".json")]
+        if stored_email and stored_email.lower() == email.strip().lower():
+            candidates.append(filepath)
+
+    if not candidates:
+        return None, False
+
+    # Pick the most recently modified file, considering mtime/size tuple
+    matching_path = max(
+        candidates,
+        key=lambda p: (os.path.getmtime(p) if os.path.exists(p) else 0,
+                       os.path.getsize(p) if os.path.exists(p) else 0),
+    )
+    return matching_path, len(candidates) > 1
+
+
 def init_storage():
     """
     Initializes the storage layout:

--- a/ikabot/helpers/sessionStorage.py
+++ b/ikabot/helpers/sessionStorage.py
@@ -280,10 +280,7 @@ def get_session_data(session, all_data=False):
     expected by Ikabot.
     """
     global_config = read_json_file(get_global_config_path(), {})
-    mail = getattr(session, "mail", None)
-    if not mail:
-        return {"shared": global_config}
-
+    mail = getattr(session, "mail", None) or ""
     user_file = get_user_file_path(mail)
     user_data = read_json_file(user_file, {})
 
@@ -322,15 +319,7 @@ def set_session_data(session, data, shared=False):
     Always reads latest disk state before writing to prevent overwriting
     concurrent updates or manual human edits.
     """
-    mail = getattr(session, "mail", None)
-    if not mail:
-        # If no mail is set, can only update global config
-        if shared and isinstance(data, dict):
-            global_config = read_json_file(get_global_config_path(), {})
-            global_config.update(data)
-            write_json_file(get_global_config_path(), global_config)
-        return
-
+    mail = getattr(session, "mail", None) or ""
     global_path = get_global_config_path()
     user_path = get_user_file_path(mail)
 
@@ -382,9 +371,7 @@ def set_session_data(session, data, shared=False):
 
 def delete_session_data(session):
     """Deletes the user's session JSON file."""
-    mail = getattr(session, "mail", None)
-    if not mail:
-        return
+    mail = getattr(session, "mail", None) or ""
     user_path = get_user_file_path(mail)
     if os.path.exists(user_path):
         try:

--- a/ikabot/helpers/sessionStorage.py
+++ b/ikabot/helpers/sessionStorage.py
@@ -1,0 +1,394 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import hashlib
+import json
+import logging
+import os
+import re
+import sys
+import time
+
+from ikabot import config
+from ikabot.helpers.aesCipher import AESCipher
+
+logger = logging.getLogger(__name__)
+
+
+def get_home_dir():
+    """Returns the user's home directory across platforms."""
+    home_env = "USERPROFILE" if config.isWindows else "HOME"
+    return os.getenv(home_env) or os.path.expanduser("~")
+
+
+def get_ikabot_dir():
+    """Returns the path to ~/.ikabot directory."""
+    return os.path.join(get_home_dir(), ".ikabot")
+
+
+def get_global_config_path():
+    """Returns the path to ~/.ikabot/global.json."""
+    return os.path.join(get_ikabot_dir(), "global.json")
+
+
+def get_users_dir():
+    """Returns the path to ~/.ikabot/users directory."""
+    return os.path.join(get_ikabot_dir(), "users")
+
+
+def get_legacy_migration_path():
+    """Returns the path to ~/.ikabot/.legacy_migration.enc."""
+    return os.path.join(get_ikabot_dir(), ".legacy_migration.enc")
+
+
+def sanitize_email(email):
+    """
+    Converts an email address into a safe, human-readable filename.
+    e.g. 'player.one@gmail.com' -> 'player.one_gmail.com'
+    """
+    if not email:
+        return "default_user"
+    email_str = str(email).strip().lower()
+    # Replace @ and forbidden characters with underscores
+    sanitized = re.sub(r'[@\s/\\:*?"<>|]', '_', email_str)
+    # Collapse multiple consecutive underscores
+    sanitized = re.sub(r'_+', '_', sanitized)
+    return sanitized.strip("._") or "user"
+
+
+def get_user_file_path(email):
+    """Returns the path to the user's JSON file: ~/.ikabot/users/<sanitized_email>.json"""
+    filename = f"{sanitize_email(email)}.json"
+    return os.path.join(get_users_dir(), filename)
+
+
+def init_storage():
+    """
+    Initializes the storage layout:
+    1. If ~/.ikabot is an existing regular file (legacy format), rename/move it
+       to ~/.ikabot_legacy_backup.enc and then into ~/.ikabot/.legacy_migration.enc.
+    2. Ensures ~/.ikabot/ and ~/.ikabot/users/ directories exist.
+    3. Initializes ~/.ikabot/global.json with defaults if it does not exist.
+    """
+    home = get_home_dir()
+    ika_path = os.path.join(home, ".ikabot")
+    temp_legacy_backup = os.path.join(home, ".ikabot_legacy_backup.enc")
+
+    # Step 1: Handle legacy single file if present
+    if os.path.exists(ika_path) and os.path.isfile(ika_path):
+        logger.info(f"Legacy .ikabot file detected at {ika_path}. Preparing migration...")
+        try:
+            os.replace(ika_path, temp_legacy_backup)
+        except Exception as e:
+            logger.error(f"Failed to rename legacy file: {e}")
+
+    # Step 2: Ensure directories exist
+    ika_dir = get_ikabot_dir()
+    os.makedirs(ika_dir, exist_ok=True)
+    os.makedirs(get_users_dir(), exist_ok=True)
+
+    # Move temporary legacy backup into .ikabot/.legacy_migration.enc
+    if os.path.exists(temp_legacy_backup):
+        legacy_dest = get_legacy_migration_path()
+        try:
+            if not os.path.exists(legacy_dest):
+                os.replace(temp_legacy_backup, legacy_dest)
+            else:
+                # Merge lines if destination already exists
+                with open(temp_legacy_backup, "r", encoding="utf-8") as f_src:
+                    src_content = f_src.read()
+                with open(legacy_dest, "a", encoding="utf-8") as f_dst:
+                    f_dst.write("\n" + src_content.strip())
+                os.remove(temp_legacy_backup)
+        except Exception as e:
+            logger.error(f"Failed moving legacy backup into directory: {e}")
+
+    # Step 3: Initialize global.json if missing
+    global_path = get_global_config_path()
+    if not os.path.exists(global_path):
+        initial_global = {
+            "logLevel": 2,
+            "telegram": {},
+            "discord": {},
+            "custom_modules": {}
+        }
+        write_json_file(global_path, initial_global)
+
+
+def read_json_file(filepath, default=None):
+    """
+    Reads JSON data freshly from disk.
+    Allows hot-swapping by humans. If the file is temporarily being written
+    or contains minor syntax errors, it retries briefly before falling back.
+    """
+    if default is None:
+        default = {}
+
+    if not os.path.exists(filepath):
+        return default
+
+    # Try up to 3 times in case another process / text editor is actively writing
+    for attempt in range(3):
+        try:
+            with open(filepath, "r", encoding="utf-8") as f:
+                content = f.read().strip()
+                if not content:
+                    return default
+                return json.loads(content)
+        except (json.JSONDecodeError, OSError) as e:
+            if attempt < 2:
+                time.sleep(0.05)
+                continue
+            logger.warning(f"Error reading JSON from {filepath}: {e}")
+            return default
+
+    return default
+
+
+def write_json_file(filepath, data):
+    """
+    Atomically writes data to disk as human-readable JSON (indent=2)
+    using a temporary file and atomic replace to prevent corruptions.
+    """
+    dir_path = os.path.dirname(filepath)
+    if dir_path:
+        os.makedirs(dir_path, exist_ok=True)
+
+    tmp_path = f"{filepath}.tmp.{os.getpid()}"
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, filepath)
+    except Exception as e:
+        logger.error(f"Failed to write JSON to {filepath}: {e}")
+        if os.path.exists(tmp_path):
+            try:
+                os.remove(tmp_path)
+            except Exception:
+                pass
+        raise
+
+
+def migrate_legacy_account(session_or_mail, password, custom_logger=None):
+    """
+    Checks if there is legacy data stored for this mail/password in ~/.ikabot/.legacy_migration.enc.
+    If found, decrypts it, migrates data to global.json and users/<email>.json,
+    and removes the migrated entry from the legacy file.
+    """
+    log = custom_logger or logger
+    mail = session_or_mail.mail if hasattr(session_or_mail, "mail") else str(session_or_mail)
+    legacy_file = get_legacy_migration_path()
+
+    if not os.path.exists(legacy_file):
+        return False
+
+    entry_key = hashlib.sha256(
+        "ikabot".encode("utf-8") + mail.encode("utf-8")
+    ).hexdigest()
+
+    try:
+        with open(legacy_file, "r", encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except Exception as e:
+        log.warning(f"Could not read legacy migration file: {e}")
+        return False
+
+    matching_line = None
+    remaining_lines = []
+
+    for line in lines:
+        line_clean = line.strip()
+        if not line_clean:
+            continue
+        if line_clean.startswith(entry_key):
+            matching_line = line_clean
+        else:
+            remaining_lines.append(line_clean)
+
+    if not matching_line:
+        return False
+
+    # Extract ciphertext (first 64 chars are entry_key)
+    ciphertext = matching_line[64:].strip()
+    cipher = AESCipher(mail, password)
+
+    try:
+        plaintext = cipher.decrypt(ciphertext)
+        legacy_data = json.loads(plaintext, strict=False)
+    except Exception as e:
+        log.warning(f"Could not decrypt legacy session data for {mail}. Password might differ or data corrupted: {e}")
+        return False
+
+    log.info(f"Successfully decrypted legacy session data for {mail}. Migrating...")
+
+    # 1. Migrate global shared items to global.json
+    global_config = read_json_file(get_global_config_path(), {})
+    user_file_path = get_user_file_path(mail)
+    user_data = read_json_file(user_file_path, {})
+
+    if "email" not in user_data:
+        user_data["email"] = mail
+    if "shared" not in user_data:
+        user_data["shared"] = {}
+    if "players" not in user_data:
+        user_data["players"] = {}
+
+    if "shared" in legacy_data and isinstance(legacy_data["shared"], dict):
+        shared_dict = legacy_data["shared"]
+        for key, val in shared_dict.items():
+            if key == "lobby":
+                # Lobby token belongs to user data
+                user_data["shared"]["lobby"] = val
+            else:
+                # Global settings (telegram, discord, logLevel, custom_modules, etc.)
+                if key not in global_config or not global_config[key]:
+                    global_config[key] = val
+
+    # 2. Migrate game accounts/players
+    for key, val in legacy_data.items():
+        if key == "shared":
+            continue
+        if isinstance(val, dict):
+            user_data["players"][key] = val
+
+    # 3. Write migrated data to disk
+    write_json_file(get_global_config_path(), global_config)
+    write_json_file(user_file_path, user_data)
+
+    # 4. Remove migrated line from legacy file
+    try:
+        if remaining_lines:
+            with open(legacy_file, "w", encoding="utf-8") as f:
+                f.write("\n".join(remaining_lines) + "\n")
+        else:
+            # All lines migrated! Remove legacy file
+            os.remove(legacy_file)
+            log.info("All legacy session entries have been migrated. Legacy file removed.")
+    except Exception as e:
+        log.warning(f"Failed updating legacy migration file after migration: {e}")
+
+    print(f"\n[Migration] Successfully migrated session data for '{mail}' to {user_file_path}\n")
+    return True
+
+
+def get_session_data(session, all_data=False):
+    """
+    ALWAYS reads fresh from disk to support hot-swapping.
+    Merges global.json and users/<email>.json to return the exact session dictionary
+    expected by Ikabot.
+    """
+    global_config = read_json_file(get_global_config_path(), {})
+    mail = getattr(session, "mail", None)
+    if not mail:
+        return {"shared": global_config}
+
+    user_file = get_user_file_path(mail)
+    user_data = read_json_file(user_file, {})
+
+    # Construct shared dict: global_config merged with user-specific shared (e.g. lobby)
+    shared_data = dict(global_config)
+    if "shared" in user_data and isinstance(user_data["shared"], dict):
+        shared_data.update(user_data["shared"])
+
+    if all_data:
+        # Full data dictionary
+        result = dict(user_data.get("players", {}))
+        result["shared"] = shared_data
+        return result
+
+    # Return player/world/server specific session data
+    username = getattr(session, "username", None)
+    mundo = getattr(session, "mundo", None)
+    servidor = getattr(session, "servidor", None)
+
+    session_data = {}
+    if username and mundo and servidor:
+        # Look in "players" first, then root of user_data for human convenience
+        players = user_data.get("players", user_data)
+        try:
+            session_data = dict(players[username][str(mundo)][servidor])
+        except (KeyError, TypeError):
+            session_data = {}
+
+    session_data["shared"] = shared_data
+    return session_data
+
+
+def set_session_data(session, data, shared=False):
+    """
+    Writes session data to disk formatted as JSON (indent=2).
+    Always reads latest disk state before writing to prevent overwriting
+    concurrent updates or manual human edits.
+    """
+    mail = getattr(session, "mail", None)
+    if not mail:
+        # If no mail is set, can only update global config
+        if shared and isinstance(data, dict):
+            global_config = read_json_file(get_global_config_path(), {})
+            global_config.update(data)
+            write_json_file(get_global_config_path(), global_config)
+        return
+
+    global_path = get_global_config_path()
+    user_path = get_user_file_path(mail)
+
+    global_config = read_json_file(global_path, {})
+    user_data = read_json_file(user_path, {})
+
+    if "email" not in user_data:
+        user_data["email"] = mail
+    if "shared" not in user_data:
+        user_data["shared"] = {}
+    if "players" not in user_data:
+        user_data["players"] = {}
+
+    if shared:
+        # Route shared items to global.json or user-level shared
+        global_keys = {"logLevel", "telegram", "discord", "custom_modules"}
+        global_modified = False
+
+        for k, v in data.items():
+            if k == "lobby":
+                user_data["shared"]["lobby"] = v
+            elif k in global_keys:
+                global_config[k] = v
+                global_modified = True
+            else:
+                # Default: save to both user shared and global config
+                user_data["shared"][k] = v
+                global_config[k] = v
+                global_modified = True
+
+        if global_modified:
+            write_json_file(global_path, global_config)
+        write_json_file(user_path, user_data)
+    else:
+        # Update specific account under players[username][mundo][servidor]
+        username = getattr(session, "username", None)
+        mundo = str(getattr(session, "mundo", ""))
+        servidor = getattr(session, "servidor", None)
+
+        if username and mundo and servidor:
+            if username not in user_data["players"]:
+                user_data["players"][username] = {}
+            if mundo not in user_data["players"][username]:
+                user_data["players"][username][mundo] = {}
+            user_data["players"][username][mundo][servidor] = data
+
+        write_json_file(user_path, user_data)
+
+
+def delete_session_data(session):
+    """Deletes the user's session JSON file."""
+    mail = getattr(session, "mail", None)
+    if not mail:
+        return
+    user_path = get_user_file_path(mail)
+    if os.path.exists(user_path):
+        try:
+            os.remove(user_path)
+            logger.info(f"Deleted user session file at {user_path}")
+        except Exception as e:
+            logger.error(f"Failed deleting user session file at {user_path}: {e}")

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -20,6 +20,12 @@ from urllib3.exceptions import InsecureRequestWarning
 from ikabot import config
 from ikabot.config import *
 from ikabot.helpers.aesCipher import *
+from ikabot.helpers.sessionStorage import (
+    get_session_data,
+    set_session_data,
+    delete_session_data,
+    migrate_legacy_account,
+)
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import banner
@@ -319,6 +325,7 @@ class Session:
 
         self.s = requests.Session()
         self.cipher = AESCipher(self.mail, self.password)
+        migrate_legacy_account(self.mail, self.password, self.logger)
         self.logger.info("__login()")
 
         # test to see if the lobby cookie in the session file is valid, this will save time on login and will reduce use of blackbox token
@@ -1391,19 +1398,23 @@ class Session:
             os._exit(0)
 
     def setSessionData(self, sessionData, shared=False):
-        """Encrypts relevant session data and writes it to the .ikabot file
+        """Writes relevant session data to disk formatted as JSON (indent=2)
         Parameters
         ----------
         sessionData : dict
-            dictionary containing relevant session data, data is written to file using AESCipher.setSessionData
+            dictionary containing relevant session data
         shared : bool
-            Indicates if the new data should be shared among all accounts asociated with the user-password
+            Indicates if the new data should be shared among all accounts associated with the user-password
         """
-        self.cipher.setSessionData(self, sessionData, shared=shared)
+        set_session_data(self, sessionData, shared=shared)
 
     def getSessionData(self):
-        """Gets relevant session data from the .ikabot file"""
-        return self.cipher.getSessionData(self)
+        """Gets fresh session data from disk (hot-reloaded)"""
+        return get_session_data(self)
+
+    def deleteSessionData(self):
+        """Deletes session data for this user from disk"""
+        delete_session_data(self)
 
 
 def normal_get(url, params={}):

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -1211,14 +1211,23 @@ class Session:
                 self.__sessionExpired()
 
     def __token(self):
-        """Generates a valid actionRequest token from the session
+        """Generates a valid actionRequest token from the session, or reuses
+        the one already stored for this account/world/server if it has one
         Returns
         -------
         token : str
             a string representing a valid actionRequest token
         """
+        sessionData = self.getSessionData()
+        token = sessionData.get("actionRequestToken")
+        if token:
+            return token
         html = self.get()
-        return re.search(r'actionRequest"?:\s*"(.*?)"', html).group(1)
+        token = re.search(r'actionRequest"?:\s*"(.*?)"', html).group(1)
+        sessionData.pop("shared", None)
+        sessionData["actionRequestToken"] = token
+        self.setSessionData(sessionData)
+        return token
 
     def get(
         self, url='', params={}, ignoreExpire=False, noIndex=False, fullResponse=False, noQuery=False, **kwargs
@@ -1421,12 +1430,18 @@ class Session:
                     assert self.__isExpired(resp) is False
                 if "TXT_ERROR_WRONG_REQUEST_ID" in resp:
                     self.logger.warning("got TXT_ERROR_WRONG_REQUEST_ID, bad actionRequest")
+                    sessionData = self.getSessionData()
+                    if sessionData.pop("actionRequestToken", None) is not None:
+                        sessionData.pop("shared", None)
+                        self.setSessionData(sessionData)
                     return self.post(
                         url=url_original,
                         payloadPost=payloadPost_original,
                         params=params_original,
                         ignoreExpire=ignoreExpire,
                         noIndex=noIndex,
+                        fullResponse=fullResponse,
+                        noQuery=noQuery,
                     )
                 # --- update developer runtime info ---
                 try:

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -45,6 +45,8 @@ class Session:
         self.logged = False
         self.blackbox = None
         self.api_user_agent = None
+        self.mail = None
+        self.password = None
         self.locale = config.IKABOT_LOCALE
         self.gf_lang = config.IKABOT_GF_LANG
         self.accept_language = config.build_accept_language(self.locale, self.gf_lang)

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -32,7 +32,7 @@ from ikabot.helpers.sessionStorage import (
 )
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
-from ikabot.helpers.gui import banner
+from ikabot.helpers.gui import banner, enter
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.varios import getDateTime, lastloginTimetoString
 from ikabot.helpers.apiComm import getNewBlackBoxToken
@@ -119,6 +119,85 @@ class Session:
 
     def __isExpired(self, html):
         return "index.php?logout" in html or '<a class="logout"' in html
+
+    def __isSessionRotated(self, html):
+        """Detects when the current session has been invalidated by logging in
+        from another device/browser. Ikariam answers such requests either with a
+        language-independent protocol command that forces a reload to the lobby:
+            [["custom",["reload",{"link":"https://lobby.ikariam.gameforge.com/es_ES",...}]]]
+        or by serving the Gameforge lobby landing page (once the redirect to it
+        has already been followed).
+        """
+        if not isinstance(html, str):
+            return False
+        # Protocol command forcing a reload to the lobby
+        if '"reload"' in html and "ikariam.gameforge.com" in html:
+            return True
+        # Lobby landing page (redirect already followed / cached)
+        if (
+            "lobby.ikariam.gameforge.com" in html
+            and ("statichub" in html or "consent.gameforge.com" in html)
+        ):
+            return True
+        return False
+
+    def __printSessionRotated(self):
+        if getattr(self, "_session_rotated_printed", False):
+            return
+        self._session_rotated_printed = True
+        msg = (
+            "\n"
+            "[ERROR] The bot's session has expired.\n"
+            "\n"
+            "If you logged into Ikariam from another browser or device, the bot's "
+            "session is closed automatically: it's not possible to keep both "
+            "sessions active at the same time.\n"
+            "\n"
+            "Alternatives:\n"
+            "  1) Use the Web Server module, which emulates the Ikariam web server "
+            "and lets you control the bot from a local URL.\n"
+            "  2) Export the browser cookies (or the other way around) from the "
+            "Settings > Import/Export cookies menu.\n"
+            "\n"
+            "At this point ikabot cannot log in again, so it will close once you "
+            "press [Enter].\n"
+        )
+        self.logger.error("Session expired: closing ikabot")
+        print(msg)
+        try:
+            enter()
+        except Exception:
+            pass
+        self.__closeIkabot()
+
+    def __closeIkabot(self):
+        """Terminates the whole ikabot application. Child processes cannot simply
+        call os._exit(1): the main menu process is blocked on event.wait() waiting
+        for the event that a killed child never fires, so it would hang forever.
+        If the parent process is another ikabot process (menu / webServer launcher),
+        terminate it as well. If we are the top-level menu process, the parent is
+        just the terminal/shell and is left alone."""
+        try:
+            import psutil
+            parent = psutil.Process(os.getppid())
+            parent_name = parent.name().lower()
+            is_python_like = parent_name.startswith("python") or "ikabot" in parent_name
+            if is_python_like:
+                parent_cmd = " ".join(parent.cmdline()).lower()
+                if "command_line" in parent_cmd or "ikabot" in parent_cmd:
+                    my_pid = os.getpid()
+                    for proc in parent.children(recursive=True):
+                        if proc.pid == my_pid:
+                            continue
+                        try:
+                            proc.terminate()
+                        except Exception:
+                            pass
+                    parent.terminate()
+                    parent.wait(timeout=5)
+        except Exception:
+            pass
+        os._exit(1)
 
     def isExpired(self, html):
         return self.__isExpired(html)
@@ -966,11 +1045,23 @@ class Session:
             self.__update_proxy(obj=old_s, sessionData=sessionData)
             try:
                 # make a request to check the connection
-                html = old_s.get(self.urlBase, verify=config.do_ssl_verify).text
+                old_resp = old_s.get(self.urlBase, verify=config.do_ssl_verify)
+                html = old_resp.text
             except Exception:
                 self.__proxy_error()
 
             cookies_are_valid = self.__isExpired(html) is False
+            # A valid-looking response that is actually the session-rotation
+            # payload (or a 404) means the stored cookies belong to a session
+            # that another login (browser/device) already took over. In that
+            # case the bot should not reuse them: a fresh login will win the
+            # session back from the other device.
+            if cookies_are_valid and self.__isSessionRotated(html):
+                self.logger.warning("Stored cookies were invalidated by another active session; performing a fresh login")
+                cookies_are_valid = False
+            if cookies_are_valid and old_resp.status_code == 404:
+                self.logger.warning("Stored cookies returned 404; performing a fresh login")
+                cookies_are_valid = False
             if cookies_are_valid:
                 self.logger.info("using old cookies")
                 used_old_cookies = True
@@ -1223,7 +1314,14 @@ class Session:
         if token:
             return token
         html = self.get()
-        token = re.search(r'actionRequest"?:\s*"(.*?)"', html).group(1)
+        if self.__isSessionRotated(html):
+            self.__printSessionRotated()
+            sys.exit(1)
+        match = re.search(r'actionRequest"?:\s*"(.*?)"', html)
+        if match is None:
+            self.__printSessionRotated()
+            sys.exit(1)
+        token = match.group(1)
         sessionData.pop("shared", None)
         sessionData["actionRequestToken"] = token
         self.setSessionData(sessionData)
@@ -1285,11 +1383,22 @@ class Session:
                 }
                 html = response.text
 
-               # modifica redirect 302
+                # modifica redirect 302
                 if response.status_code == 302:
                     location = response.headers.get('Location', '')
                     if 'lobby.ikariam.gameforge.com' in location:
-                        raise AssertionError("Redirect to lobby detected")
+                        self.logger.error(f"Redirected to lobby: {location}")
+                        self.__printSessionRotated()
+                        sys.exit(1)
+
+                # session rotated, redirect followed by requests (final status 200)
+                for resp in response.history:
+                    if resp is not None and resp.status_code == 302:
+                        location = resp.headers.get('Location', '')
+                        if 'lobby.ikariam.gameforge.com' in location:
+                            self.logger.error(f"Redirected to lobby: {location}")
+                            self.__printSessionRotated()
+                            sys.exit(1)
 
                 # handle 404 processes
                 if response.status_code == 404:
@@ -1298,7 +1407,8 @@ class Session:
                         self.logger.error(f"404 Not Found received from Ikariam: {url}")
                         # Only expire session if the main entry point fails
                         if "index.php" in url:
-                            raise AssertionError("404 Not Found on index.php - Session likely expired")
+                            self.__printSessionRotated()
+                            sys.exit(1)
                     else:
                         # Local Web Server or external 404 should not trigger re-login
                         self.logger.warning(f"Local/External 404 detected at: {url}. Ignoring.")
@@ -1310,6 +1420,9 @@ class Session:
                     raise requests.exceptions.ConnectionError  # repeat after 10 minutes
                 if ignoreExpire is False:
                     assert self.__isExpired(html) is False
+                if self.__isSessionRotated(html):
+                    self.__printSessionRotated()
+                    sys.exit(1)
                 # --- update developer runtime info ---
                 try:
                     self.dev_api_host = self.host
@@ -1409,14 +1522,26 @@ class Session:
                 if response.status_code == 302:
                     location = response.headers.get('Location', '')
                     if 'lobby.ikariam.gameforge.com' in location:
-                        raise AssertionError("Redirect to lobby detected")
+                        self.logger.error(f"Redirected to lobby: {location}")
+                        self.__printSessionRotated()
+                        sys.exit(1)
+
+                # session rotated, redirect followed by requests (final status 200)
+                for resp_hist in response.history:
+                    if resp_hist is not None and resp_hist.status_code == 302:
+                        location = resp_hist.headers.get('Location', '')
+                        if 'lobby.ikariam.gameforge.com' in location:
+                            self.logger.error(f"Redirected to lobby: {location}")
+                            self.__printSessionRotated()
+                            sys.exit(1)
 
                 # handle 404 processes
                 if response.status_code == 404:
                     # If the POST was to Ikariam and failed, it's a session issue
                     if self.host in url:
                         self.logger.error(f"404 Not Found received from Ikariam POST: {url}")
-                        raise AssertionError("404 Not Found - Session likely expired")
+                        self.__printSessionRotated()
+                        sys.exit(1)
                     else:
                         # Probably a request to the local web server's invalid route
                         self.logger.warning(f"Local 404 detected on POST: {url}. Ignoring.")
@@ -1428,6 +1553,9 @@ class Session:
                     raise requests.exceptions.ConnectionError  # repeat after 10 minutes
                 if ignoreExpire is False:
                     assert self.__isExpired(resp) is False
+                if self.__isSessionRotated(resp):
+                    self.__printSessionRotated()
+                    sys.exit(1)
                 if "TXT_ERROR_WRONG_REQUEST_ID" in resp:
                     self.logger.warning("got TXT_ERROR_WRONG_REQUEST_ID, bad actionRequest")
                     sessionData = self.getSessionData()

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -25,6 +25,10 @@ from ikabot.helpers.sessionStorage import (
     set_session_data,
     delete_session_data,
     migrate_legacy_account,
+    get_saved_users,
+    get_user_file_path,
+    get_users_dir,
+    find_user_file_for_email,
 )
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
@@ -267,6 +271,21 @@ class Session:
             sys.exit("The provided gf-token-production cookie is invalid or expired\n")
         return auth_token
 
+    def __ask_password_if_needed(self):
+        """
+        If the user resumed a saved session without a password (empty mail /
+        saved account selection), asking it on the first prompt would defeat
+        the cookie-based login. But if the lobby cookie has expired we now do
+        need the real credentials to re-authenticate via mauth. Ask for them
+        only in that moment, and only in the parent process.
+        """
+        if not self.password and self.padre:
+            if not self.mail:
+                print("\nThe stored session has expired and no account mail was provided.")
+                self.mail = read(msg="Mail: ")
+            print("\nThe stored session has expired. Enter the password for '{}':".format(self.mail))
+            self.password = getpass.getpass("Password: ")
+
     def __load_new_blackbox_token(self, allow_lobby_cookie_fallback=False):
         try:
             if self.padre:
@@ -310,11 +329,46 @@ class Session:
             banner()
 
             self.mail = read(msg="Mail:")
+            entered_mail = self.mail
 
-            if len(config.predetermined_input) != 0:
-                self.password = config.predetermined_input.pop(0)
+            if not entered_mail:
+                # No mail provided (Enter/Enter). Never ask for a password:
+                # use the stored cookies from default_user.json, or if that
+                # does not exist but other accounts are saved, let the user
+                # pick one so its cookies are reused.
+                default_user_file = get_user_file_path("")
+                saved_users = get_saved_users()
+                if saved_users and not os.path.exists(default_user_file):
+                    if len(saved_users) == 1:
+                        selected = saved_users[0]
+                        print("\nNo default account found, using saved account: {}".format(selected))
+                    else:
+                        print("\nNo default account found. Select a saved account:")
+                        for i, user in enumerate(saved_users, start=1):
+                            print("  {}. {}".format(i, user))
+                        selected = saved_users[read(min=1, max=len(saved_users), digit=True) - 1]
+                    self.mail = selected
+                # Cookies are already stored, skip password prompt (unless we
+                # already learned the password during a previous retry)
+                if not self.password:
+                    self.password = ""
             else:
-                self.password = getpass.getpass("Password:")
+                # Mail was typed. If it matches a saved account, reuse its cookies
+                # instead of asking for a password.
+                matching_path, has_duplicates = find_user_file_for_email(entered_mail)
+                if matching_path:
+                    if has_duplicates:
+                        print("\n[Warning] '{}' is present in multiple session files. Using the most recently modified one.".format(entered_mail))
+                    self.password = ""
+                else:
+                    # No saved session for this mail
+                    print("\nNo saved session found for '{}'.".format(entered_mail))
+                    print("Check the files in: {}".format(get_users_dir()))
+                    print("If they are outdated or corrupted, delete them and log in manually.")
+                    if len(config.predetermined_input) != 0:
+                        self.password = config.predetermined_input.pop(0)
+                    else:
+                        self.password = getpass.getpass("Password:")
 
             banner()
 
@@ -341,6 +395,7 @@ class Session:
         if not self.__test_lobby_cookie():
 
             self.logger.warning("Getting new lobby cookie")
+            self.__ask_password_if_needed()
             blackbox_loaded = self.__load_new_blackbox_token(allow_lobby_cookie_fallback=True)
             if not blackbox_loaded:
                 auth_token = self.s.cookies["gf-token-production"]


### PR DESCRIPTION
This PR brings a couple of changes:

1) Moving .ikabot file into .ikabot directory with different files
2) Removed encryption completely (hooray fuck encryption)
3) .ikabot dir now contains files for account data in different dirs and global data as well
4) We are now using .json files with indent=2 so they are human readable
5) Files should be hot-swappable, meaning that ikabot will READ FROM DISK every time it wants to access a session storage variable. This is intended for players who want to modify their tokens / configs / whatevers and have them apply immediately while ikabot is running. This will of course require those modules to have to read from the session data but that is not the concern or responsibility of this commit
6) Automatic migration from the previous system (if .ikabot files is present it will be decrypted on first successful login and data will be migrated to this new system

This needs significant testing before it's merged into main, but it's **_WORTH IT_**!