### PR TITLE
Feature/saved account selector

### DIFF
--- a/ikabot/helpers/sessionStorage.py
+++ b/ikabot/helpers/sessionStorage.py
@@ -62,6 +62,26 @@ def get_user_file_path(email):
     return os.path.join(get_users_dir(), filename)
 
 
+def get_saved_users():
+    """Returns the list of saved user accounts (their emails) found in ~/.ikabot/users,
+    excluding the default account used for empty mail."""
+    users_dir = get_users_dir()
+    if not os.path.isdir(users_dir):
+        return []
+
+    saved = []
+    for filename in sorted(os.listdir(users_dir)):
+        if not filename.endswith(".json"):
+            continue
+        if filename == f"{sanitize_email('')}.json":
+            continue
+        filepath = os.path.join(users_dir, filename)
+        data = read_json_file(filepath, {})
+        email = data.get("email") or filename[: -len(".json")]
+        saved.append(email)
+    return saved
+
+
 def init_storage():
     """
     Initializes the storage layout:

--- a/ikabot/helpers/sessionStorage.py
+++ b/ikabot/helpers/sessionStorage.py
@@ -82,6 +82,44 @@ def get_saved_users():
     return saved
 
 
+def find_user_file_for_email(email):
+    """
+    Resolves an email to its session JSON file(s) in ~/.ikabot/users.
+
+    Returns a tuple (matching_path, duplicados):
+      - matching_path: path of the most recently modified matching file,
+                       or None if no user file matches the email.
+      - duplicados:    True if more than one file matches the email.
+    The default_user file (empty mail) is never considered a match.
+    """
+    users_dir = get_users_dir()
+    if not os.path.isdir(users_dir):
+        return None, False
+
+    candidates = []
+    for filename in os.listdir(users_dir):
+        if not filename.endswith(".json"):
+            continue
+        if filename == f"{sanitize_email('')}.json":
+            continue
+        filepath = os.path.join(users_dir, filename)
+        data = read_json_file(filepath, {})
+        stored_email = data.get("email") or filename[: -len(".json")]
+        if stored_email and stored_email.lower() == email.strip().lower():
+            candidates.append(filepath)
+
+    if not candidates:
+        return None, False
+
+    # Pick the most recently modified file, considering mtime/size tuple
+    matching_path = max(
+        candidates,
+        key=lambda p: (os.path.getmtime(p) if os.path.exists(p) else 0,
+                       os.path.getsize(p) if os.path.exists(p) else 0),
+    )
+    return matching_path, len(candidates) > 1
+
+
 def init_storage():
     """
     Initializes the storage layout:

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -27,6 +27,8 @@ from ikabot.helpers.sessionStorage import (
     migrate_legacy_account,
     get_saved_users,
     get_user_file_path,
+    get_users_dir,
+    find_user_file_for_email,
 )
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
@@ -312,12 +314,13 @@ class Session:
             banner()
 
             self.mail = read(msg="Mail:")
+            entered_mail = self.mail
 
-            selected_saved = False
-            if not self.mail:
-                # No mail provided. If the default user file does not exist but
-                # other saved accounts do, let the user pick one so the saved
-                # cookies can be reused without re-entering credentials.
+            if not entered_mail:
+                # No mail provided (Enter/Enter). Never ask for a password:
+                # use the stored cookies from default_user.json, or if that
+                # does not exist but other accounts are saved, let the user
+                # pick one so its cookies are reused.
                 default_user_file = get_user_file_path("")
                 saved_users = get_saved_users()
                 if saved_users and not os.path.exists(default_user_file):
@@ -330,15 +333,25 @@ class Session:
                             print("  {}. {}".format(i, user))
                         selected = saved_users[read(min=1, max=len(saved_users), digit=True) - 1]
                     self.mail = selected
-                    # Credentials are already stored for this account, skip password prompt
+                # Cookies are already stored, skip password prompt
+                self.password = ""
+            else:
+                # Mail was typed. If it matches a saved account, reuse its cookies
+                # instead of asking for a password.
+                matching_path, has_duplicates = find_user_file_for_email(entered_mail)
+                if matching_path:
+                    if has_duplicates:
+                        print("\n[Warning] '{}' is present in multiple session files. Using the most recently modified one.".format(entered_mail))
                     self.password = ""
-                    selected_saved = True
-
-            if not selected_saved:
-                if len(config.predetermined_input) != 0:
-                    self.password = config.predetermined_input.pop(0)
                 else:
-                    self.password = getpass.getpass("Password:")
+                    # No saved session for this mail
+                    print("\nNo saved session found for '{}'.".format(entered_mail))
+                    print("Check the files in: {}".format(get_users_dir()))
+                    print("If they are outdated or corrupted, delete them and log in manually.")
+                    if len(config.predetermined_input) != 0:
+                        self.password = config.predetermined_input.pop(0)
+                    else:
+                        self.password = getpass.getpass("Password:")
 
             banner()
 

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -271,6 +271,21 @@ class Session:
             sys.exit("The provided gf-token-production cookie is invalid or expired\n")
         return auth_token
 
+    def __ask_password_if_needed(self):
+        """
+        If the user resumed a saved session without a password (empty mail /
+        saved account selection), asking it on the first prompt would defeat
+        the cookie-based login. But if the lobby cookie has expired we now do
+        need the real credentials to re-authenticate via mauth. Ask for them
+        only in that moment, and only in the parent process.
+        """
+        if not self.password and self.padre:
+            if not self.mail:
+                print("\nThe stored session has expired and no account mail was provided.")
+                self.mail = read(msg="Mail: ")
+            print("\nThe stored session has expired. Enter the password for '{}':".format(self.mail))
+            self.password = getpass.getpass("Password: ")
+
     def __load_new_blackbox_token(self, allow_lobby_cookie_fallback=False):
         try:
             if self.padre:
@@ -333,8 +348,10 @@ class Session:
                             print("  {}. {}".format(i, user))
                         selected = saved_users[read(min=1, max=len(saved_users), digit=True) - 1]
                     self.mail = selected
-                # Cookies are already stored, skip password prompt
-                self.password = ""
+                # Cookies are already stored, skip password prompt (unless we
+                # already learned the password during a previous retry)
+                if not self.password:
+                    self.password = ""
             else:
                 # Mail was typed. If it matches a saved account, reuse its cookies
                 # instead of asking for a password.
@@ -378,6 +395,7 @@ class Session:
         if not self.__test_lobby_cookie():
 
             self.logger.warning("Getting new lobby cookie")
+            self.__ask_password_if_needed()
             blackbox_loaded = self.__load_new_blackbox_token(allow_lobby_cookie_fallback=True)
             if not blackbox_loaded:
                 auth_token = self.s.cookies["gf-token-production"]

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -25,6 +25,8 @@ from ikabot.helpers.sessionStorage import (
     set_session_data,
     delete_session_data,
     migrate_legacy_account,
+    get_saved_users,
+    get_user_file_path,
 )
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
@@ -311,10 +313,32 @@ class Session:
 
             self.mail = read(msg="Mail:")
 
-            if len(config.predetermined_input) != 0:
-                self.password = config.predetermined_input.pop(0)
-            else:
-                self.password = getpass.getpass("Password:")
+            selected_saved = False
+            if not self.mail:
+                # No mail provided. If the default user file does not exist but
+                # other saved accounts do, let the user pick one so the saved
+                # cookies can be reused without re-entering credentials.
+                default_user_file = get_user_file_path("")
+                saved_users = get_saved_users()
+                if saved_users and not os.path.exists(default_user_file):
+                    if len(saved_users) == 1:
+                        selected = saved_users[0]
+                        print("\nNo default account found, using saved account: {}".format(selected))
+                    else:
+                        print("\nNo default account found. Select a saved account:")
+                        for i, user in enumerate(saved_users, start=1):
+                            print("  {}. {}".format(i, user))
+                        selected = saved_users[read(min=1, max=len(saved_users), digit=True) - 1]
+                    self.mail = selected
+                    # Credentials are already stored for this account, skip password prompt
+                    self.password = ""
+                    selected_saved = True
+
+            if not selected_saved:
+                if len(config.predetermined_input) != 0:
+                    self.password = config.predetermined_input.pop(0)
+                else:
+                    self.password = getpass.getpass("Password:")
 
             banner()
 


### PR DESCRIPTION
After the session storage rework, sessions are saved per-user under ~/.ikabot/users/<email>.json. Pressing Enter/Enter (empty mail) logged in using the stored cookies, but once those cookies expired, the mauth re-login was attempted with empty identity/password, which Gameforge rejects with HTTP 400 and forces manual fallback.
These changes make the saved-session login flow smoother and add an automatic credential fallback that only kicks in when it is actually needed:
- Empty mail / Enter-Enter: no password prompt at all. The stored cookies from default_user.json are reused; if that file does not exist but other accounts are saved, the user picks one from a numbered list (auto-selected when there is only one account).
- Typed mail matching a saved session: the stored cookies are reused without asking for a password. If the mail exists in more than one file, the most recently modified one is used and a warning is shown.
- Typed mail with no matching session: the user is told to review the files in the users/ directory (the path is printed) or delete them and log in manually, then asked for the password as usual.
- Expired lobby cookie: the real mail and password are requested only at the moment the cookie test fails, then reused for the mauth re-authentication. On retries, an already-entered password is preserved.
- Unchanged behavior when the cookie is still valid: no password prompt.