### PR TITLE
Fix resource distribution with blockaded harbours

### DIFF
--- a/ikabot/function/distributeResources.py
+++ b/ikabot/function/distributeResources.py
@@ -124,11 +124,16 @@ def distribute_evenly(session, resource_type, cities_ids, cities):
             city_url + cityID
         )  # load html from the get request for that particular city
         city = getCity(html)  # convert the html to a city object
+        if city.get("harbourOccupied"):
+            continue
 
         resourceTotal += city["availableResources"][
             resource_type
         ]  # the cities resources are added to the total
         allCities[cityID] = city  # adds the city to all cities
+
+    if len(allCities) < 2:
+        return []
 
     # if a city doesn't have enough storage to fit resourceAverage
     # ikabot will send enough resources to fill the store to the max

--- a/tests/ikabot/function/test_distributeResources.py
+++ b/tests/ikabot/function/test_distributeResources.py
@@ -27,6 +27,42 @@ def test_distribute_evenly(monkeypatch, session, cities):
     ]
 
 
+def test_distribute_evenly_excludes_blockaded_cities(monkeypatch, session, cities):
+    resource_type = materials_names_tec.index("wine")
+    cities[0]["harbourOccupied"] = True
+    cities[0]["availableResources"][resource_type] = 600
+    cities[1]["availableResources"][resource_type] = 600
+    cities[2]["availableResources"][resource_type] = 0
+    monkeypatch.setattr(
+        ikabot.function.distributeResources, "getCity", lambda city: city
+    )
+
+    routes = distribute_evenly(
+        session, resource_type, [city["id"] for city in cities], cities
+    )
+
+    assert routes == [(cities[1], cities[2], cities[2]["islandId"], 0, 300, 0, 0, 0)]
+
+
+def test_distribute_evenly_with_only_blockaded_cities_returns_no_routes(
+    monkeypatch, session, cities
+):
+    for city in cities:
+        city["harbourOccupied"] = True
+    monkeypatch.setattr(
+        ikabot.function.distributeResources, "getCity", lambda city: city
+    )
+
+    routes = distribute_evenly(
+        session,
+        materials_names_tec.index("wine"),
+        [city["id"] for city in cities],
+        cities,
+    )
+
+    assert routes == []
+
+
 @pytest.fixture()
 def cities():
     city_1 = {


### PR DESCRIPTION
## Problem

Uniform resource distribution currently includes cities whose harbour is blockaded (`harbourOccupied`).

These cities cannot participate in normal resource transports, but their resources are still included in the distribution calculation. This can both generate impossible transport routes and distort the resource balance for the remaining cities.

## Fix

Exclude blockaded cities before calculating resource totals, averages, surpluses, deficits, and transport routes.

The distribution is therefore recalculated only between eligible cities. If fewer than two eligible cities remain, no routes are generated.

## Tests

Added regression coverage for a distribution containing a blockaded city, verifying that the remaining eligible cities are rebalanced correctly, and for the case where no eligible cities remain.

- `python -m pytest tests/ikabot/function/test_distributeResources.py -q`
- `python -m pytest tests/ikabot -q`