### PR TITLE
Fix SyntaxWarning: invalid escape sequence in loginDaily regex

### DIFF
--- a/ikabot/function/loginDaily.py
+++ b/ikabot/function/loginDaily.py
@@ -326,7 +326,7 @@ def do_it(session, wine_city, wood_city, luxury_city, favour_tasks, collect_ambr
                         True  # we don't want to spam the message, only once is enough
                     )
                 break
-            matches = re.findall("<tr([\S\s]*?)tr>", html)
+            matches = re.findall(r"<tr([\S\s]*?)tr>", html)
             rows = [
                 matches[1],
                 matches[2],


### PR DESCRIPTION
This showed up as a SyntaxWarning in the repo's CI tests and is a preventive fix for future Python versions

<img width="878" height="276" alt="image" src="https://github.com/user-attachments/assets/f3044a95-02a3-45c1-be2a-5693e6a52906" />
