### PR TITLE
fix: initialize mail and password in Session.__init__

### DIFF
--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -45,6 +45,8 @@ class Session:
         self.logged = False
         self.blackbox = None
         self.api_user_agent = None
+        self.mail = None
+        self.password = None
         self.locale = config.IKABOT_LOCALE
         self.gf_lang = config.IKABOT_GF_LANG
         self.accept_language = config.build_accept_language(self.locale, self.gf_lang)


### PR DESCRIPTION
The new login flow added by #443 reads self.password/self.mail in __login() and __ask_password_if_needed(), but __init__ never set them, crashing the "run ikabot" CI smoke test with AttributeError when the mail is empty.