### PR TITLE
Update CI Python test matrix to 3.10-3.14

### DIFF
--- a/.github/workflows/test_and_run.yml
+++ b/.github/workflows/test_and_run.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Drops Python 3.9 (EOL) from the test matrix and adds 3.13 and 3.14, which are already stable releases.