### PR TITLE
Fix session smoke test and update Python test matrix

### DIFF
--- a/.github/workflows/test_and_run.yml
+++ b/.github/workflows/test_and_run.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - name: Checkout
@@ -44,5 +44,5 @@ jobs:
         python -m pytest tests/ikabot
     - name: Run ikabot
       run: |
-        printf "\n\n" | python -m ikabot &> log.log || cat log.log
+        printf "\n\n\n" | python -m ikabot &> log.log || cat log.log
         grep "Obtaining new blackbox token, please wait..." log.log && exit 0 || exit 1


### PR DESCRIPTION
The new login flow in `Session.__login()` now asks for the mail twice before falling back to a password prompt when there is no saved session (mail, mail again inside `__ask_password_if_needed`, then password), so the `Run ikabot` smoke test needs one extra blank line to reach the blackbox token step. Also drops Python 3.9 (EOL) from the test matrix and adds 3.13/3.14.