### PR TITLE
Persist the actionRequest token instead of fetching it every POST

### DIFF
--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -1238,12 +1238,17 @@ class Session:
                 self.__sessionExpired()
 
     def __token(self):
-        """Generates a valid actionRequest token from the session
+        """Generates a valid actionRequest token from the session, or reuses
+        the one already stored for this account/world/server if it has one
         Returns
         -------
         token : str
             a string representing a valid actionRequest token
         """
+        sessionData = self.getSessionData()
+        token = sessionData.get("actionRequestToken")
+        if token:
+            return token
         html = self.get()
         if self.__isSessionRotated(html):
             self.__printSessionRotated()
@@ -1252,7 +1257,11 @@ class Session:
         if match is None:
             self.__printSessionRotated()
             sys.exit(1)
-        return match.group(1)
+        token = match.group(1)
+        sessionData.pop("shared", None)
+        sessionData["actionRequestToken"] = token
+        self.setSessionData(sessionData)
+        return token
 
     def get(
         self, url='', params={}, ignoreExpire=False, noIndex=False, fullResponse=False, noQuery=False, **kwargs
@@ -1485,12 +1494,18 @@ class Session:
                     sys.exit(1)
                 if "TXT_ERROR_WRONG_REQUEST_ID" in resp:
                     self.logger.warning("got TXT_ERROR_WRONG_REQUEST_ID, bad actionRequest")
+                    sessionData = self.getSessionData()
+                    if sessionData.pop("actionRequestToken", None) is not None:
+                        sessionData.pop("shared", None)
+                        self.setSessionData(sessionData)
                     return self.post(
                         url=url_original,
                         payloadPost=payloadPost_original,
                         params=params_original,
                         ignoreExpire=ignoreExpire,
                         noIndex=noIndex,
+                        fullResponse=fullResponse,
+                        noQuery=noQuery,
                     )
                 # --- update developer runtime info ---
                 try:


### PR DESCRIPTION
The session token is now reused instead of requesting a new one for every action, saving requests, keeping consistency, and speeding up both the web server and the rest of the functions.