### PR TITLE
Bring session-expiry detection (#448) into Rework-session-storage

### DIFF
--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -32,7 +32,7 @@ from ikabot.helpers.sessionStorage import (
 )
 from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
-from ikabot.helpers.gui import banner
+from ikabot.helpers.gui import banner, enter
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.varios import getDateTime, lastloginTimetoString
 from ikabot.helpers.apiComm import getNewBlackBoxToken
@@ -119,6 +119,85 @@ class Session:
 
     def __isExpired(self, html):
         return "index.php?logout" in html or '<a class="logout"' in html
+
+    def __isSessionRotated(self, html):
+        """Detects when the current session has been invalidated by logging in
+        from another device/browser. Ikariam answers such requests either with a
+        language-independent protocol command that forces a reload to the lobby:
+            [["custom",["reload",{"link":"https://lobby.ikariam.gameforge.com/es_ES",...}]]]
+        or by serving the Gameforge lobby landing page (once the redirect to it
+        has already been followed).
+        """
+        if not isinstance(html, str):
+            return False
+        # Protocol command forcing a reload to the lobby
+        if '"reload"' in html and "ikariam.gameforge.com" in html:
+            return True
+        # Lobby landing page (redirect already followed / cached)
+        if (
+            "lobby.ikariam.gameforge.com" in html
+            and ("statichub" in html or "consent.gameforge.com" in html)
+        ):
+            return True
+        return False
+
+    def __printSessionRotated(self):
+        if getattr(self, "_session_rotated_printed", False):
+            return
+        self._session_rotated_printed = True
+        msg = (
+            "\n"
+            "[ERROR] The bot's session has expired.\n"
+            "\n"
+            "If you logged into Ikariam from another browser or device, the bot's "
+            "session is closed automatically: it's not possible to keep both "
+            "sessions active at the same time.\n"
+            "\n"
+            "Alternatives:\n"
+            "  1) Use the Web Server module, which emulates the Ikariam web server "
+            "and lets you control the bot from a local URL.\n"
+            "  2) Export the browser cookies (or the other way around) from the "
+            "Settings > Import/Export cookies menu.\n"
+            "\n"
+            "At this point ikabot cannot log in again, so it will close once you "
+            "press [Enter].\n"
+        )
+        self.logger.error("Session expired: closing ikabot")
+        print(msg)
+        try:
+            enter()
+        except Exception:
+            pass
+        self.__closeIkabot()
+
+    def __closeIkabot(self):
+        """Terminates the whole ikabot application. Child processes cannot simply
+        call os._exit(1): the main menu process is blocked on event.wait() waiting
+        for the event that a killed child never fires, so it would hang forever.
+        If the parent process is another ikabot process (menu / webServer launcher),
+        terminate it as well. If we are the top-level menu process, the parent is
+        just the terminal/shell and is left alone."""
+        try:
+            import psutil
+            parent = psutil.Process(os.getppid())
+            parent_name = parent.name().lower()
+            is_python_like = parent_name.startswith("python") or "ikabot" in parent_name
+            if is_python_like:
+                parent_cmd = " ".join(parent.cmdline()).lower()
+                if "command_line" in parent_cmd or "ikabot" in parent_cmd:
+                    my_pid = os.getpid()
+                    for proc in parent.children(recursive=True):
+                        if proc.pid == my_pid:
+                            continue
+                        try:
+                            proc.terminate()
+                        except Exception:
+                            pass
+                    parent.terminate()
+                    parent.wait(timeout=5)
+        except Exception:
+            pass
+        os._exit(1)
 
     def isExpired(self, html):
         return self.__isExpired(html)
@@ -966,11 +1045,23 @@ class Session:
             self.__update_proxy(obj=old_s, sessionData=sessionData)
             try:
                 # make a request to check the connection
-                html = old_s.get(self.urlBase, verify=config.do_ssl_verify).text
+                old_resp = old_s.get(self.urlBase, verify=config.do_ssl_verify)
+                html = old_resp.text
             except Exception:
                 self.__proxy_error()
 
             cookies_are_valid = self.__isExpired(html) is False
+            # A valid-looking response that is actually the session-rotation
+            # payload (or a 404) means the stored cookies belong to a session
+            # that another login (browser/device) already took over. In that
+            # case the bot should not reuse them: a fresh login will win the
+            # session back from the other device.
+            if cookies_are_valid and self.__isSessionRotated(html):
+                self.logger.warning("Stored cookies were invalidated by another active session; performing a fresh login")
+                cookies_are_valid = False
+            if cookies_are_valid and old_resp.status_code == 404:
+                self.logger.warning("Stored cookies returned 404; performing a fresh login")
+                cookies_are_valid = False
             if cookies_are_valid:
                 self.logger.info("using old cookies")
                 used_old_cookies = True
@@ -1223,7 +1314,14 @@ class Session:
         if token:
             return token
         html = self.get()
-        token = re.search(r'actionRequest"?:\s*"(.*?)"', html).group(1)
+        if self.__isSessionRotated(html):
+            self.__printSessionRotated()
+            sys.exit(1)
+        match = re.search(r'actionRequest"?:\s*"(.*?)"', html)
+        if match is None:
+            self.__printSessionRotated()
+            sys.exit(1)
+        token = match.group(1)
         sessionData.pop("shared", None)
         sessionData["actionRequestToken"] = token
         self.setSessionData(sessionData)
@@ -1285,11 +1383,22 @@ class Session:
                 }
                 html = response.text
 
-               # modifica redirect 302
+                # modifica redirect 302
                 if response.status_code == 302:
                     location = response.headers.get('Location', '')
                     if 'lobby.ikariam.gameforge.com' in location:
-                        raise AssertionError("Redirect to lobby detected")
+                        self.logger.error(f"Redirected to lobby: {location}")
+                        self.__printSessionRotated()
+                        sys.exit(1)
+
+                # session rotated, redirect followed by requests (final status 200)
+                for resp in response.history:
+                    if resp is not None and resp.status_code == 302:
+                        location = resp.headers.get('Location', '')
+                        if 'lobby.ikariam.gameforge.com' in location:
+                            self.logger.error(f"Redirected to lobby: {location}")
+                            self.__printSessionRotated()
+                            sys.exit(1)
 
                 # handle 404 processes
                 if response.status_code == 404:
@@ -1298,7 +1407,8 @@ class Session:
                         self.logger.error(f"404 Not Found received from Ikariam: {url}")
                         # Only expire session if the main entry point fails
                         if "index.php" in url:
-                            raise AssertionError("404 Not Found on index.php - Session likely expired")
+                            self.__printSessionRotated()
+                            sys.exit(1)
                     else:
                         # Local Web Server or external 404 should not trigger re-login
                         self.logger.warning(f"Local/External 404 detected at: {url}. Ignoring.")
@@ -1310,6 +1420,9 @@ class Session:
                     raise requests.exceptions.ConnectionError  # repeat after 10 minutes
                 if ignoreExpire is False:
                     assert self.__isExpired(html) is False
+                if self.__isSessionRotated(html):
+                    self.__printSessionRotated()
+                    sys.exit(1)
                 # --- update developer runtime info ---
                 try:
                     self.dev_api_host = self.host
@@ -1409,14 +1522,26 @@ class Session:
                 if response.status_code == 302:
                     location = response.headers.get('Location', '')
                     if 'lobby.ikariam.gameforge.com' in location:
-                        raise AssertionError("Redirect to lobby detected")
+                        self.logger.error(f"Redirected to lobby: {location}")
+                        self.__printSessionRotated()
+                        sys.exit(1)
+
+                # session rotated, redirect followed by requests (final status 200)
+                for resp_hist in response.history:
+                    if resp_hist is not None and resp_hist.status_code == 302:
+                        location = resp_hist.headers.get('Location', '')
+                        if 'lobby.ikariam.gameforge.com' in location:
+                            self.logger.error(f"Redirected to lobby: {location}")
+                            self.__printSessionRotated()
+                            sys.exit(1)
 
                 # handle 404 processes
                 if response.status_code == 404:
                     # If the POST was to Ikariam and failed, it's a session issue
                     if self.host in url:
                         self.logger.error(f"404 Not Found received from Ikariam POST: {url}")
-                        raise AssertionError("404 Not Found - Session likely expired")
+                        self.__printSessionRotated()
+                        sys.exit(1)
                     else:
                         # Probably a request to the local web server's invalid route
                         self.logger.warning(f"Local 404 detected on POST: {url}. Ignoring.")
@@ -1428,6 +1553,9 @@ class Session:
                     raise requests.exceptions.ConnectionError  # repeat after 10 minutes
                 if ignoreExpire is False:
                     assert self.__isExpired(resp) is False
+                if self.__isSessionRotated(resp):
+                    self.__printSessionRotated()
+                    sys.exit(1)
                 if "TXT_ERROR_WRONG_REQUEST_ID" in resp:
                     self.logger.warning("got TXT_ERROR_WRONG_REQUEST_ID, bad actionRequest")
                     sessionData = self.getSessionData()


### PR DESCRIPTION
Rework-session-storage diverged from master before #448 (session-expiry detection / __closeIkabot) was merged, so it could not be merged back into master cleanly. This brings #448 into this branch, resolving the one conflict in Session.__token() (both changed the same lines) so the branch keeps all three: the folder-based session storage, the session-expiry detection, and the actionRequest token persistence from #454.

Only session.py is touched, and only where the two features actually overlapped.