### PR TITLE
Separate function modules into @configurator and @task decorators

### DIFF
--- a/ikabot/function/UpgradeUnits.py
+++ b/ikabot/function/UpgradeUnits.py
@@ -157,7 +157,13 @@ def wait_for_upgrade_start(session, city_id, position, tab):
         time.sleep(1)
         attempts += 1
 
+from ikabot.helpers.decorators import configurator, task
+
+
+@task("UpgradeUnits")
 def execute_sequential_upgrades(session, city_id, city_name, position, tab, tasks):
+    info = f"Workshop upgrade: {len(tasks)} upgrades queued"
+    setInfoSignal(session, info)
     while tasks:
         wait_for_upgrade_completion(session, city_id, position, tab)
         html = session.get(city_url + str(city_id))
@@ -188,11 +194,9 @@ def execute_sequential_upgrades(session, city_id, city_name, position, tab, task
 
     session.setStatus("All workshop upgrades completed")
 
+
+@configurator
 def UpgradeUnits(session, event, stdin_fd, predetermined_input):
-
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-
     cities_ids, cities_info = getIdsOfCities(session)
 
     workshops = []
@@ -214,8 +218,7 @@ def UpgradeUnits(session, event, stdin_fd, predetermined_input):
     if not workshops:
         print("\nNo workshop found in any city.")
         enter()
-        event.set()
-        return
+        return None
 
     selected_workshops = workshops
     if len(workshops) > 1:
@@ -223,38 +226,31 @@ def UpgradeUnits(session, event, stdin_fd, predetermined_input):
         for idx, w in enumerate(workshops, start=1):
             lvl = w.get("level", 0)
             print(f"[{idx}] {w['name']}, workshop level {lvl}")
-        print("\nEnter numbers separated by space (e.g. 1 3) or 'all' to pick every city:")
-        sel = read().split()
-        if "all" in sel:
-            selected_workshops = workshops
-        else:
-            selected_workshops = []
-            for token in sel:
-                if token.isdigit():
-                    i = int(token)
-                    if 0 < i <= len(workshops):
-                        selected_workshops.append(workshops[i - 1])
+        print("\nEnter a number to pick a city:")
+        sel = read().strip()
+        selected_workshops = []
+        if sel.isdigit():
+            i = int(sel)
+            if 0 < i <= len(workshops):
+                selected_workshops.append(workshops[i - 1])
+        
         if not selected_workshops:
             enter()
-            event.set()
-            return
+            return None
 
-    for idx, w in enumerate(selected_workshops):
+    w = selected_workshops[0]
+    print(f"\n=== City {w['name']} (id {w['city_id']}) ===")
+    return run_workshop_upgrade_interface(
+        session,
+        w["city_id"],
+        w["name"],
+        w["position"],
+        w["action_request"],
+        w.get("level", 0),
+    )
 
-        print(f"\n=== City {w['name']} (id {w['city_id']}) ===")
-        finalize = idx == len(selected_workshops) - 1
-        run_workshop_upgrade_interface(
-            session,
-            w["city_id"],
-            w["name"],
-            w["position"],
-            w["action_request"],
-            event,
-            finalize,
-            w.get("level", 0),
-        )
 
-def run_workshop_upgrade_interface(session, city_id, city_name, position, action_request, event, finalize=True, workshop_level=0):
+def run_workshop_upgrade_interface(session, city_id, city_name, position, action_request, workshop_level=0):
     print("\nWhat would you like to upgrade?")
     print("[1] Units")
     print("[2] Ships")
@@ -277,16 +273,12 @@ def run_workshop_upgrade_interface(session, city_id, city_name, position, action
         data = json.loads(response, strict=False)
     except Exception as e:
         enter()
-        if finalize:
-            event.set()
-        return
+        return None
 
     template_data = next((b[1] for b in data if isinstance(b, list) and b[0] == "updateTemplateData"), None)
     if not template_data:
         enter()
-        if finalize:
-            event.set()
-        return
+        return None
 
     complete_data = template_data.get("completeData", {})
     unit_details = template_data.get("unitDetails", {})
@@ -322,9 +314,7 @@ def run_workshop_upgrade_interface(session, city_id, city_name, position, action
     if not tasks:
         print("\nNo upgrade options available in this city (workshop level may be too low).")
         enter()
-        if finalize:
-            event.set()
-        return
+        return None
 
     for idx, task in enumerate(tasks, start=1):
         print(f"[{idx}] {task['unit']} ({task['type']}): Level {task['from']}")
@@ -335,9 +325,7 @@ def run_workshop_upgrade_interface(session, city_id, city_name, position, action
 
     if not selected_tasks:
         enter()
-        if finalize:
-            event.set()
-        return
+        return None
 
     upgrade_levels = {}
     print("\nFor each selected unit, enter the desired target level.")
@@ -402,9 +390,7 @@ def run_workshop_upgrade_interface(session, city_id, city_name, position, action
     if not selected_tasks:
         print("\nNo upgrades selected after target evaluation. Nothing to do.")
         enter()
-        if finalize:
-            event.set()
-        return
+        return None
 
     print("\nThe following individual upgrades will be queued:")
     for i, t in enumerate(selected_tasks, start=1):
@@ -418,14 +404,13 @@ def run_workshop_upgrade_interface(session, city_id, city_name, position, action
     if confirm != 'y':
         print("Operation cancelled by user.")
         enter()
-        if finalize:
-            event.set()
-        return
-    session.setStatus(f"Queued {len(selected_tasks)} upgrades | Gold: {total_gold:,} | Crystal: {total_crystal:,}")
-    info = f"Workshop upgrade: {len(selected_tasks)} upgrades queued"
-    set_child_mode(session)
-    setInfoSignal(session, info)
-    thread = threading.Thread(target=execute_sequential_upgrades, args=(session, city_id, city_name, position, filter_type, selected_tasks))
-    thread.start()
-    if finalize:
-        event.set()
+        return None
+
+    return {
+        "session": session,
+        "city_id": city_id,
+        "city_name": city_name,
+        "position": position,
+        "tab": filter_type,
+        "tasks": selected_tasks
+    }

--- a/ikabot/function/activateMiracle.py
+++ b/ikabot/function/activateMiracle.py
@@ -10,7 +10,7 @@ from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import *
 
@@ -166,158 +166,6 @@ def chooseIsland(islands):
     return island
 
 
-def activateMiracle(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-
-        islands = obtainMiraclesAvailable(session)
-        if islands == []:
-            print("There are no miracles available.")
-            enter()
-            event.set()
-            return
-
-        island = chooseIsland(islands)
-        if island is None:
-            event.set()
-            return
-
-        if island["available"]:
-            print("\nThe miracle {} (level {}) will be activated".format(island["wonderName"], island["wonderActivationLevel"]))
-            print("Proceed? [Y/n]")
-            activate_miracle_input = read(values=["y", "Y", "n", "N", ""])
-            if activate_miracle_input.lower() == "n":
-                event.set()
-                return
-
-            miracle_activation_result = activateMiracleHttpCall(session, island)
-
-            if miracle_activation_result[1][1][0] == "error":
-                print(
-                    "The miracle {} could not be activated.".format(
-                        island["wonderName"]
-                    )
-                )
-                enter()
-                event.set()
-                return
-
-            data = miracle_activation_result[2][1]
-            for elem in data:
-                if "countdown" in data[elem]:
-                    enddate = data[elem]["countdown"]["enddate"]
-                    currentdate = data[elem]["countdown"]["currentdate"]
-                    break
-            wait_time = int(float(enddate)) - int(float(currentdate))
-
-            print("The miracle {} was activated.".format(island["wonderName"]))
-            enter()
-            banner()
-
-            while True:
-                print("Do you wish to activate it again when it is finished? [y/N]")
-
-                reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
-                if reactivate_again_input.lower() != "y":
-                    event.set()
-                    return
-
-                iterations = read(msg="How many times?: ", digit=True, min=0)
-
-                if iterations == 0:
-                    event.set()
-                    return
-
-                duration = wait_time * iterations
-
-                print("It will finish in:{}".format(daysHoursMinutes(duration)))
-
-                print("Proceed? [Y/n]")
-                reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
-                if reactivate_again_input.lower() == "n":
-                    banner()
-                    continue
-                break
-        else:
-            print(
-                "\nThe miracle {} will be activated in {}".format(
-                    island["wonderName"], daysHoursMinutes(island["available_in"])
-                )
-            )
-            print("Proceed? [Y/n]")
-            user_confirm = read(values=["y", "Y", "n", "N", ""])
-            if user_confirm.lower() == "n":
-                event.set()
-                return
-            wait_time = island["available_in"]
-            iterations = 1
-
-            print("\nThe mirable will be activated.")
-            enter()
-            banner()
-
-            while True:
-                print("Do you wish to activate it again when it is finished? [y/N]")
-
-                reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
-                again = reactivate_again_input.lower() == "y"
-                if again is True:
-                    try:
-                        iterations = read(msg="How many times?: ", digit=True, min=0)
-                    except KeyboardInterrupt:
-                        iterations = 1
-                        break
-
-                    if iterations == 0:
-                        iterations = 1
-                        break
-
-                    iterations += 1
-                    duration = wait_time * iterations
-                    print("It is not possible to calculate the time of finalization. (at least: {})".format(daysHoursMinutes(duration)))
-                    print("Proceed? [Y/n]")
-
-                    try:
-                        activate_input = read(values=["y", "Y", "n", "N", ""])
-                    except KeyboardInterrupt:
-                        iterations = 1
-                        break
-
-                    if activate_input.lower() == "n":
-                        iterations = 1
-                        banner()
-                        continue
-                break
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI activate the miracle {} {:d} times\n".format(
-        island["wonderName"], iterations
-    )
-    setInfoSignal(session, info)
-    try:
-        do_it(session, island, iterations)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
 def wait_for_miracle(session, island):
     """
     Parameters
@@ -365,6 +213,7 @@ def wait_for_miracle(session, island):
         wait(wait_time + 5)
 
 
+@task("activateMiracle")
 def do_it(session, island, iterations):
     """
     Parameters
@@ -373,6 +222,10 @@ def do_it(session, island, iterations):
     island : dict
     iterations : int
     """
+    info = "\nI activate the miracle {} {:d} times\n".format(
+        island["wonderName"], iterations
+    )
+    setInfoSignal(session, info)
     iterations_left = iterations
     session.setStatus(f"Waiting to activate {island['wonderName']}...")
     for i in range(iterations):
@@ -393,3 +246,133 @@ def do_it(session, island, iterations):
         )
         msg = "Miracle {} successfully activated".format(island["wonderName"])
         sendToBotDebug(session, msg, debugON_activateMiracle)
+@configurator
+def activateMiracle(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+
+    islands = obtainMiraclesAvailable(session)
+    if islands == []:
+        print("There are no miracles available.")
+        enter()
+        return None
+
+    island = chooseIsland(islands)
+    if island is None:
+        return None
+
+    if island["available"]:
+        print("\nThe miracle {} (level {}) will be activated".format(island["wonderName"], island["wonderActivationLevel"]))
+        print("Proceed? [Y/n]")
+        activate_miracle_input = read(values=["y", "Y", "n", "N", ""])
+        if activate_miracle_input.lower() == "n":
+            event.set()
+            return
+
+        miracle_activation_result = activateMiracleHttpCall(session, island)
+
+        if miracle_activation_result[1][1][0] == "error":
+            print(
+                "The miracle {} could not be activated.".format(
+                    island["wonderName"]
+                )
+            )
+            enter()
+            event.set()
+            return
+
+        data = miracle_activation_result[2][1]
+        for elem in data:
+            if "countdown" in data[elem]:
+                enddate = data[elem]["countdown"]["enddate"]
+                currentdate = data[elem]["countdown"]["currentdate"]
+                break
+        wait_time = int(float(enddate)) - int(float(currentdate))
+
+        print("The miracle {} was activated.".format(island["wonderName"]))
+        enter()
+        banner()
+
+        while True:
+            print("Do you wish to activate it again when it is finished? [y/N]")
+
+            reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
+            if reactivate_again_input.lower() != "y":
+                event.set()
+                return
+
+            iterations = read(msg="How many times?: ", digit=True, min=0)
+
+            if iterations == 0:
+                event.set()
+                return
+
+            duration = wait_time * iterations
+
+            print("It will finish in:{}".format(daysHoursMinutes(duration)))
+
+            print("Proceed? [Y/n]")
+            reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
+            if reactivate_again_input.lower() == "n":
+                banner()
+                continue
+            break
+    else:
+        print(
+            "\nThe miracle {} will be activated in {}".format(
+                island["wonderName"], daysHoursMinutes(island["available_in"])
+            )
+        )
+        print("Proceed? [Y/n]")
+        user_confirm = read(values=["y", "Y", "n", "N", ""])
+        if user_confirm.lower() == "n":
+            event.set()
+            return
+        wait_time = island["available_in"]
+        iterations = 1
+
+        print("\nThe mirable will be activated.")
+        enter()
+        banner()
+
+        while True:
+            print("Do you wish to activate it again when it is finished? [y/N]")
+
+            reactivate_again_input = read(values=["y", "Y", "n", "N", ""])
+            again = reactivate_again_input.lower() == "y"
+            if again is True:
+                try:
+                    iterations = read(msg="How many times?: ", digit=True, min=0)
+                except KeyboardInterrupt:
+                    iterations = 1
+                    break
+
+                if iterations == 0:
+                    iterations = 1
+                    break
+
+                iterations += 1
+                duration = wait_time * iterations
+                print("It is not possible to calculate the time of finalization. (at least: {})".format(daysHoursMinutes(duration)))
+                print("Proceed? [Y/n]")
+
+                try:
+                    activate_input = read(values=["y", "Y", "n", "N", ""])
+                except KeyboardInterrupt:
+                    iterations = 1
+                    break
+
+                if activate_input.lower() == "n":
+                    iterations = 1
+                    banner()
+                    continue
+            break
+    return {"session": session, "island": island, "iterations": iterations}
+

--- a/ikabot/function/activateShrine.py
+++ b/ikabot/function/activateShrine.py
@@ -11,14 +11,8 @@ from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.resources import *
 from ikabot.helpers.varios import *
-from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.botComm import *
-
-wait_time = 60 * 60 * 12  # 12 hours, wait_time*6 equals total shrine grace time of 72h
-last_donation_status = ""
-last_donation_time = ""
-current_favor = ""
-selected_gods = ""
+from ikabot.helpers.decorators import configurator, task
 
 
 def findShrine(session):
@@ -44,149 +38,6 @@ def findShrine(session):
                     shrinePos,
                 )  # Return as soon as Shrine and it's position is found
     return None, None  # Return None if not found
-
-
-def do_it(session, godids, mode, times):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    godids : list[int]
-    mode : int
-    times : int
-    """
-    try:
-        favor_needed = (
-            len(godids) * 100
-        )  # Calculate the required amount of favor to donate all selected gods at once
-        shrineCity, shrinePos = findShrine(session)
-        if shrineCity is not None and shrinePos is not None:
-            cityid, pos = shrineCity, shrinePos
-        else:
-            msg = "Shrine city or building position was not found."
-            sendToBot(session, msg)
-            event.set()
-            return
-
-        if mode == 1 or mode == 3:
-            for _ in range(times):
-                favor = getFavor(session, cityid, pos)
-                while favor < favor_needed:
-                    session.setStatus(
-                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
-                    )
-                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
-                    favor = getFavor(session, cityid, pos)
-                for godid in godids:
-                    donateShrine(session, godid, cityid, pos)
-                    time.sleep(2)
-
-            if mode == 1:
-                event.set()
-                return
-            mode = 2  # If mode is both, set mode for loop
-
-        if mode == 2:
-            while True:
-                favor = getFavor(session, cityid, pos)
-                while favor < favor_needed:
-                    session.setStatus(
-                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
-                    )
-                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
-                    favor = getFavor(session, cityid, pos)
-                for godid in godids:
-                    donateShrine(session, godid, cityid, pos)
-                    time.sleep(2)
-                for i in range(6):  # 12h * 6 = 72 hours
-                    time.sleep(wait_time)  # 12h
-                    global current_favor
-                    current_favor = getFavor(session, cityid, pos)
-                    global last_donation_status
-                    last_donation_status = f"Activated {selected_gods} @{last_donation_time}, current favor: {current_favor}"
-                    session.setStatus(
-                        last_donation_status
-                    )  # Update only current favor value in the task status message, activation/donation time remains
-
-    except Exception as e:
-        msg = f"Error in activateShrine:\n\n{e}"
-        sendToBot(session, msg)
-        event.set()
-        return
-
-
-def activateShrine(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd : int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    banner()
-    godids = []
-
-    while True:
-        print(
-            """Which God(s) would you like to activate autonomously? 
-    (0) Continue
-    (1) Pan (Wood)
-    (2) Dionysus (Wine)
-    (3) Tyche (Marble)
-    (4) Plutus (Gold)
-    (5) Theia (Crystal)
-    (6) Hephaestus (Sulphur)
-    """
-        )
-        god = read(min=0, max=6, digit=True)
-        if god == 0:
-            if len(godids) == 0:
-                event.set()
-                return
-            named_gods = [gods(godid) for godid in godids]
-            gods_str = ", ".join(named_gods) if len(named_gods) > 1 else named_gods[0]
-            global selected_gods
-            selected_gods = gods_str
-            break
-        else:
-            godids.append(god)
-            continue
-
-    print("")
-    print(
-        """Would you like to activate the selected God(s) a specific amount of times or autonomously every 70 hours?
-(1) Specific amount of times in a row
-(2) Autonomously every 70 hours
-(3) Both
-"""
-    )
-    mode = read(min=1, max=3, digit=True)
-    if mode == 1 or mode == 3:
-        print("How many times would you like to activate the selected God(s)?")
-        times = read(min=1, max=10, digit=True)
-    if mode == 2:
-        mode = 2
-        times = 0
-
-    set_child_mode(session)
-    event.set()
-
-    try:
-        do_it(
-            session,
-            tuple(godids),
-            mode,
-            times,
-        )
-
-    except Exception as e:
-        msg = f"Error in activateShrine:\n\n{e}"
-        sendToBot(session, msg)
-    finally:
-        session.logout()
 
 
 def gods(godid):
@@ -229,7 +80,7 @@ def getFavor(session, cityid, pos):
         return 0
 
 
-def donateShrine(session, godid, cityid, pos):
+def donateShrine(session, godid, cityid, pos, selected_gods):
     """Donates to the selected Gods and updates the task status accordingly
     Parameters
     ----------
@@ -237,13 +88,148 @@ def donateShrine(session, godid, cityid, pos):
     godid : int
     cityid : int
     pos : int
+    selected_gods : str
     """
     url = f"action=DonateFavorToGod&godId={godid}&position={pos}&backgroundView=city&currentCityId={cityid}&templateView=shrineOfOlympus&currentTab=tabOverview&actionRequest={actionRequest}&ajax=1"
     session.post(url)
-    global current_favor
     current_favor = getFavor(session, cityid, pos)
-    global last_donation_time
     last_donation_time = getDateTime()
-    global last_donation_status
     last_donation_status = f"Activated {selected_gods} @{last_donation_time}, current favor: {current_favor}"
     session.setStatus(last_donation_status)
+    return current_favor, last_donation_time, last_donation_status
+
+
+@task("activateShrine")
+def do_it(session, godids, mode, times, selected_gods, wait_time):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    godids : tuple[int]
+    mode : int
+    times : int
+    selected_gods : str
+    wait_time : int
+    """
+    last_donation_status = ""
+    last_donation_time = ""
+    current_favor = ""
+    try:
+        favor_needed = (
+            len(godids) * 100
+        )  # Calculate the required amount of favor to donate all selected gods at once
+        shrineCity, shrinePos = findShrine(session)
+        if shrineCity is not None and shrinePos is not None:
+            cityid, pos = shrineCity, shrinePos
+        else:
+            msg = "Shrine city or building position was not found."
+            sendToBot(session, msg)
+            return
+
+        if mode == 1 or mode == 3:
+            for _ in range(times):
+                favor = getFavor(session, cityid, pos)
+                while favor < favor_needed:
+                    session.setStatus(
+                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
+                    )
+                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
+                    favor = getFavor(session, cityid, pos)
+                for godid in godids:
+                    current_favor, last_donation_time, last_donation_status = donateShrine(session, godid, cityid, pos, selected_gods)
+                    time.sleep(2)
+
+            if mode == 1:
+                return
+            mode = 2  # If mode is both, set mode for loop
+
+        if mode == 2:
+            while True:
+                favor = getFavor(session, cityid, pos)
+                while favor < favor_needed:
+                    session.setStatus(
+                        f"Not enough favor @{getDateTime()}, re-trying in 3h."
+                    )
+                    time.sleep(wait_time / 4)  # 12h / 4 = 3 hours
+                    favor = getFavor(session, cityid, pos)
+                for godid in godids:
+                    current_favor, last_donation_time, last_donation_status = donateShrine(session, godid, cityid, pos, selected_gods)
+                    time.sleep(2)
+                for i in range(6):  # 12h * 6 = 72 hours
+                    time.sleep(wait_time)  # 12h
+                    current_favor = getFavor(session, cityid, pos)
+                    last_donation_status = f"Activated {selected_gods} @{last_donation_time}, current favor: {current_favor}"
+                    session.setStatus(
+                        last_donation_status
+                    )  # Update only current favor value in the task status message, activation/donation time remains
+
+    except Exception as e:
+        msg = f"Error in activateShrine:\n\n{e}"
+        sendToBot(session, msg)
+        return
+
+
+@configurator
+def activateShrine(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd : int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+    godids = []
+    selected_gods = ""
+    wait_time = 60 * 60 * 12  # 12 hours, wait_time*6 equals total shrine grace time of 72h
+
+    while True:
+        print(
+            """Which God(s) would you like to activate autonomously? 
+    (0) Continue
+    (1) Pan (Wood)
+    (2) Dionysus (Wine)
+    (3) Tyche (Marble)
+    (4) Plutus (Gold)
+    (5) Theia (Crystal)
+    (6) Hephaestus (Sulphur)
+    """
+        )
+        god = read(min=0, max=6, digit=True)
+        if god == 0:
+            if len(godids) == 0:
+                return None
+            named_gods = [gods(godid) for godid in godids]
+            gods_str = ", ".join(named_gods) if len(named_gods) > 1 else named_gods[0]
+            selected_gods = gods_str
+            break
+        else:
+            godids.append(god)
+            continue
+
+    print("")
+    print(
+        """Would you like to activate the selected God(s) a specific amount of times or autonomously every 70 hours?
+(1) Specific amount of times in a row
+(2) Autonomously every 70 hours
+(3) Both
+"""
+    )
+    mode = read(min=1, max=3, digit=True)
+    if mode == 1 or mode == 3:
+        print("How many times would you like to activate the selected God(s)?")
+        times = read(min=1, max=10, digit=True)
+    if mode == 2:
+        mode = 2
+        times = 0
+
+    return {
+        "session": session,
+        "godids": tuple(godids),
+        "mode": mode,
+        "times": times,
+        "selected_gods": selected_gods,
+        "wait_time": wait_time,
+    }
+

--- a/ikabot/function/alertAttacks.py
+++ b/ikabot/function/alertAttacks.py
@@ -8,54 +8,9 @@ import traceback
 from ikabot.function.vacationMode import activateVacationMode
 from ikabot.helpers.botComm import *
 from ikabot.helpers.gui import enter
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import daysHoursMinutes
-
-
-def alertAttacks(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        if checkTelegramData(session) is False:
-            event.set()
-            return
-
-        banner()
-        default = 20
-        minutes = read(
-            msg=
-                "How often should I search for attacks?(min:3, default: {:d}): ".format(default),
-            min=3,
-            default=default,
-        )
-        # min_units = read(msg=_('Attacks with less than how many units should be ignored? (default: 0): '), digit=True, default=0)
-        print("I will check for attacks every {:d} minutes".format(minutes))
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI check for attacks every {:d} minutes\n".format(minutes)
-    setInfoSignal(session, info)
-    try:
-        do_it(session, minutes)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
 
 
 def respondToAttack(session):
@@ -94,6 +49,7 @@ def respondToAttack(session):
         time.sleep(max(0, 60 * 3 - elapsed))
 
 
+@task("alertAttacks")
 def do_it(session, minutes):
     """
     Parameters
@@ -101,6 +57,8 @@ def do_it(session, minutes):
     session : ikabot.web.session.Session
     minutes : int
     """
+    info = "\nI check for attacks every {:d} minutes\n".format(minutes)
+    setInfoSignal(session, info)
 
     # this thread lets the user react to an attack once the alert is sent
     thread = threading.Thread(target=respondToAttack, args=(session,))
@@ -168,3 +126,29 @@ def do_it(session, minutes):
 
         elapsed = time.time() - start_time
         time.sleep(max(0, minutes * 60 - elapsed))
+@configurator
+def alertAttacks(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    if checkTelegramData(session) is False:
+        return None
+
+    banner()
+    default = 20
+    minutes = read(
+        msg=
+            "How often should I search for attacks?(min:3, default: {:d}): ".format(default),
+        min=3,
+        default=default,
+    )
+    # min_units = read(msg=_('Attacks with less than how many units should be ignored? (default: 0): '), digit=True, default=0)
+    print("I will check for attacks every {:d} minutes".format(minutes))
+    enter()
+    return {"session": session, "minutes": minutes}
+

--- a/ikabot/function/alertLowWine.py
+++ b/ikabot/function/alertLowWine.py
@@ -13,63 +13,13 @@ from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import getIdsOfCities
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.resources import getWineConsumptionPerHour, getAvailableResources, getProductionPerHour
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import daysHoursMinutes
 from ikabot.helpers.planRoutes import *
 
 getcontext().prec = 30
-
-def alertLowWine(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        if checkTelegramData(session) is False:
-            event.set()
-            return
-        banner()
-        hours = read(
-            msg=(
-                "How many hours should be left until the wine runs out in a city so that it's alerted? : "
-            ),
-            min=1,
-        )
-        auto_transfer = read(msg=("Would you like to automatically transfer wine if necessary? (y/n) : ")).strip().lower()
-        
-        if auto_transfer in ["y", "yes"]:
-            auto_transfer = True
-            transfer_amount = read(msg=("How much wine should be sent automatically? : "), min=1)
-        else:
-            auto_transfer = False
-            transfer_amount = 0
-        print("It will be alerted when the wine runs out in less than {:d} hours in any city, and {:,d} wine will be transferred if necessary.".format(hours, transfer_amount))
-
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = ("\nI alert if the wine runs out in less than {:d} hours\n".format(hours))
-    setInfoSignal(session, info)
-    try:
-        do_it(session, hours, auto_transfer, transfer_amount)
-    except Exception as e:
-        msg = (f"Error in:\n{info}\nCause:\n{traceback.format_exc()}")
-        sendToBot(session, msg)
-    finally:
-        session.logout()
 
 def getMovementsFromHtml(session):
     """
@@ -123,6 +73,7 @@ def isWineTransportInProgress(session, destinationCityId):
 
     return None
 
+@task("alertLowWine")
 def do_it(session, hours, auto_transfer, transfer_amount):
     """
     Parameters
@@ -132,6 +83,8 @@ def do_it(session, hours, auto_transfer, transfer_amount):
     auto_transfer : bool
     transfer_amount : int
     """
+    info = "\nI alert if the wine runs out in less than {:d} hours\n".format(hours)
+    setInfoSignal(session, info)
     was_alerted = {}
     message_log = []
     routes = []  # Store all routes for batch execution
@@ -248,3 +201,35 @@ def do_it(session, hours, auto_transfer, transfer_amount):
             executeRoutes(session, routes, useFreighters=False)
             routes.clear()
         time.sleep(60 * 60)
+@configurator
+def alertLowWine(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    if checkTelegramData(session) is False:
+        return None
+    banner()
+    hours = read(
+        msg=(
+            "How many hours should be left until the wine runs out in a city so that it's alerted? : "
+        ),
+        min=1,
+    )
+    auto_transfer = read(msg=("Would you like to automatically transfer wine if necessary? (y/n) : ")).strip().lower()
+    
+    if auto_transfer in ["y", "yes"]:
+        auto_transfer = True
+        transfer_amount = read(msg=("How much wine should be sent automatically? : "), min=1)
+    else:
+        auto_transfer = False
+        transfer_amount = 0
+    print("It will be alerted when the wine runs out in less than {:d} hours in any city, and {:,d} wine will be transferred if necessary.".format(hours, transfer_amount))
+
+    enter()
+    return {"session": session, "hours": hours, "auto_transfer": auto_transfer, "transfer_amount": transfer_amount}
+

--- a/ikabot/function/attackBarbarians.py
+++ b/ikabot/function/attackBarbarians.py
@@ -10,6 +10,7 @@ from decimal import *
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.naval import *
@@ -260,66 +261,6 @@ def plan_attack(session, city, babarians_info):
     return plan
 
 
-def attackBarbarians(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-
-        island = choose_island(session)
-        if island is None:
-            event.set()
-            return
-        ship_capacity, freighter_capacity = getShipCapacity(session)
-        babarians_info = get_barbarians_lv(session, island, ship_capacity)
-
-        banner()
-        print("The barbarians have:")
-        for name, amount in babarians_info["troops"]:
-            print("{} units of {}".format(amount, name))
-        print("")
-
-        banner()
-        print("From which city do you want to attack?")
-        city = chooseCity(session)
-
-        plan = plan_attack(session, city, babarians_info)
-        if plan is None:
-            event.set()
-            return
-
-        banner()
-        print(
-            "The barbarians in [{}:{}] will be attacked.".format(
-                island["x"], island["y"]
-            )
-        )
-        enter()
-
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI attack the barbarians in [{}:{}]\n".format(island["x"], island["y"])
-    setInfoSignal(session, info)
-    try:
-        do_it(session, island, city, babarians_info, plan, ship_capacity)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
 
 
 def get_unit_data(session, city_id, unit_id):
@@ -635,7 +576,10 @@ def loot(session, island, city, units_data, loot_round, ship_capacity):
         session.post(params=attack_data)
 
 
+@task("attackBarbarians")
 def do_it(session, island, city, babarians_info, plan, ship_capacity):
+    info = "\nI attack the barbarians in [{}:{}]\n".format(island["x"], island["y"])
+    setInfoSignal(session, info)
 
     units_data = {}
 
@@ -717,3 +661,45 @@ def do_it(session, island, city, babarians_info, plan, ship_capacity):
     last_round = plan[-1]
     if last_round["loot"]:
         loot(session, city, island, units_data, last_round, ship_capacity)
+
+
+@configurator
+def attackBarbarians(session, event, stdin_fd, predetermined_input):
+    banner()
+
+    island = choose_island(session)
+    if island is None:
+        return None
+    ship_capacity, freighter_capacity = getShipCapacity(session)
+    babarians_info = get_barbarians_lv(session, island, ship_capacity)
+
+    banner()
+    print("The barbarians have:")
+    for name, amount in babarians_info["troops"]:
+        print("{} units of {}".format(amount, name))
+    print("")
+
+    banner()
+    print("From which city do you want to attack?")
+    city = chooseCity(session)
+
+    plan = plan_attack(session, city, babarians_info)
+    if plan is None:
+        return None
+
+    banner()
+    print(
+        "The barbarians in [{}:{}] will be attacked.".format(
+            island["x"], island["y"]
+        )
+    )
+    enter()
+
+    return {
+        "session": session,
+        "island": island,
+        "city": city,
+        "babarians_info": babarians_info,
+        "plan": plan,
+        "ship_capacity": ship_capacity,
+    }

--- a/ikabot/function/autoBarbarians.py
+++ b/ikabot/function/autoBarbarians.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.naval import *
@@ -138,156 +139,7 @@ FIVE_MINUTES = 5 * 60
 DEVELOPMENT = False
 
 
-def autoBarbarians(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    ship_capacity, freighter_capacity = getShipCapacity(session)
-    try:
-        banner()
-        print(
-            
-                "{}⚠️ BEWARE - THE BARBARIAN GRIND TO BE CARRIED OUT MORE EFFICIENTLY REQUIRES THE FOLLOWING RESOURCES ⚠️{}\n".format(
-                    bcolors.WARNING, bcolors.ENDC
-                )
-            
-        )
-        print(
-            "- You need to leave at least 3 merchant ships available.",
-            "- You leave 2 extra rams available in the city of origin.",
-            "- It is not recommended that merchant ships be used during the grind, as maximizing their use increases the efficiency and effectiveness of attacks.",
-            sep="\n",
-        )
-        print(
-            
-                "\nDo you agree that failure to comply with these rules will result in you losing out on resources? [y/N]"
-            
-        )
-        if read(values=["y", "Y", "n", "N"], default="n") in ["n", "N"]:
-            event.set()
-            return
 
-        banner()
-        island = choose_island(session)
-        if island is None:
-            event.set()
-            return
-
-        banner()
-        print("From which city do you want to attack?")
-        city = chooseCity(session)
-        if city is None:
-            event.set()
-            return
-
-        has_rams = has_units_in_city(session, city, {"307": 1})
-        if has_rams is False:
-            print(
-                
-                    "\nYou do not have 2 or more battering rams in this city, the lack of them may prevent you from collecting all the resources present in the barbarian village, are you sure you want to continue anyway? [y/N]"
-                
-            )
-            if read(values=["y", "Y", "n", "N"], default="n") in ["n", "N"]:
-                event.set()
-                return
-
-        banner()
-        if DEVELOPMENT is True:
-            islands = obtainMiraclesAvailable(session)
-            hephaestus_max = is_hephaestus_max(islands)
-            auto_activate_hephaestus = False
-            if hephaestus_max:
-                print(
-                    
-                        "Do you want to keep activating your Hephaestus to maximize the grind? [Y/n]"
-                    
-                )
-                activate_miracle_input = read(values=["y", "Y", "n", "N", ""])
-                auto_activate_hephaestus = (
-                    True if activate_miracle_input in ("y", "Y") else False
-                )
-
-        schematic = DEFAULT_SCHEMATICS["WITHOUT_HEPHAESTUS"]
-        if DEVELOPMENT is True:
-            banner()
-            schematic_option = choose_schematic()
-            if schematic_option is None:
-                event.set()
-                return
-
-            if schematic_option == 1:
-                if auto_activate_hephaestus:
-                    schematic = DEFAULT_SCHEMATICS["WITH_HEPHAESTUS"]
-                pass
-            elif schematic_option == 2:
-                # TODO do the part where the user can select a custom structure
-                pass
-
-        banner()
-        success, schematic_informations = get_schematic_information(
-            session,
-            city,
-            schematic,
-            ship_capacity,
-            is_in_island=True if city["islandId"] == island["id"] else False,
-        )
-        units_data = schematic_informations["units_data"]
-        schematic_units = schematic_informations["schematic_units"]
-        main_city_units = schematic_informations["main_city_units"]
-        schematic_ships = schematic_informations["schematic_ships"]
-
-        ships_available = waitForArrival(session)
-        print(
-            "For this sequence of attacks you need to have the following troops:\n"
-        )
-        print_grid_units(
-            schematic_units["total"], main_city_units, schematic_ships, ships_available
-        )
-        if success is False:
-            print(
-                
-                    "\nYou do not have all the units needed to start this attack sequence, you want to continue executing the attack only as far as possible? [Y/n]"
-                
-            )
-            if read(values=["y", "Y", "n", "N"], default="y") in ["n", "N"]:
-                event.set()
-                return
-
-        banner()
-        need_float_city = check_need_float_city(schematic)
-        float_city = None
-        if need_float_city is True:
-            float_city = choose_float_city(session, island)
-            if float_city is None:
-                event.set()
-                return
-
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI grinding the barbarians in [{}:{}]\n".format(
-        island["x"], island["y"]
-    )
-    setInfoSignal(session, info)
-
-    try:
-        do_it(session, island, city, float_city, schematic, units_data, ship_capacity)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
 
 
 def choose_island(session):
@@ -578,7 +430,12 @@ def has_units_in_city(session, city, units):
     )
 
 
+@task("autoBarbarians")
 def do_it(session, island, city, float_city, schematic, units_data, ship_capacity):
+    info = "\nI grinding the barbarians in [{}:{}]\n".format(
+        island["x"], island["y"]
+    )
+    setInfoSignal(session, info)
     attempts = {"ships": 0}
     first_loop = True
     while True:
@@ -1006,3 +863,128 @@ def wait_for_looting(session, city, island):
     wait(wait_time + 5)
 
     wait_for_looting(session, city, island)
+
+
+@configurator
+def autoBarbarians(session, event, stdin_fd, predetermined_input):
+    ship_capacity, freighter_capacity = getShipCapacity(session)
+    banner()
+    print(
+        
+            "{}⚠️ BEWARE - THE BARBARIAN GRIND TO BE CARRIED OUT MORE EFFICIENTLY REQUIRES THE FOLLOWING RESOURCES ⚠️{}\n".format(
+                bcolors.WARNING, bcolors.ENDC
+            )
+        
+    )
+    print(
+        "- You need to leave at least 3 merchant ships available.",
+        "- You leave 2 extra rams available in the city of origin.",
+        "- It is not recommended that merchant ships be used during the grind, as maximizing their use increases the efficiency and effectiveness of attacks.",
+        sep="\n",
+    )
+    print(
+        
+            "\nDo you agree that failure to comply with these rules will result in you losing out on resources? [y/N]"
+        
+    )
+    if read(values=["y", "Y", "n", "N"], default="n") in ["n", "N"]:
+        return None
+
+    banner()
+    island = choose_island(session)
+    if island is None:
+        return None
+
+    banner()
+    print("From which city do you want to attack?")
+    city = chooseCity(session)
+    if city is None:
+        return None
+
+    has_rams = has_units_in_city(session, city, {"307": 1})
+    if has_rams is False:
+        print(
+            
+                "\nYou do not have 2 or more battering rams in this city, the lack of them may prevent you from collecting all the resources present in the barbarian village, are you sure you want to continue anyway? [y/N]"
+            
+        )
+        if read(values=["y", "Y", "n", "N"], default="n") in ["n", "N"]:
+            return None
+
+    banner()
+    if DEVELOPMENT is True:
+        islands = obtainMiraclesAvailable(session)
+        hephaestus_max = is_hephaestus_max(islands)
+        auto_activate_hephaestus = False
+        if hephaestus_max:
+            print(
+                
+                    "Do you want to keep activating your Hephaestus to maximize the grind? [Y/n]"
+                
+            )
+            activate_miracle_input = read(values=["y", "Y", "n", "N", ""])
+            auto_activate_hephaestus = (
+                True if activate_miracle_input in ("y", "Y") else False
+            )
+
+    schematic = DEFAULT_SCHEMATICS["WITHOUT_HEPHAESTUS"]
+    if DEVELOPMENT is True:
+        banner()
+        schematic_option = choose_schematic()
+        if schematic_option is None:
+            return None
+
+        if schematic_option == 1:
+            if auto_activate_hephaestus:
+                schematic = DEFAULT_SCHEMATICS["WITH_HEPHAESTUS"]
+            pass
+        elif schematic_option == 2:
+            # TODO do the part where the user can select a custom structure
+            pass
+
+    banner()
+    success, schematic_informations = get_schematic_information(
+        session,
+        city,
+        schematic,
+        ship_capacity,
+        is_in_island=True if city["islandId"] == island["id"] else False,
+    )
+    units_data = schematic_informations["units_data"]
+    schematic_units = schematic_informations["schematic_units"]
+    main_city_units = schematic_informations["main_city_units"]
+    schematic_ships = schematic_informations["schematic_ships"]
+
+    ships_available = waitForArrival(session)
+    print(
+        "For this sequence of attacks you need to have the following troops:\n"
+    )
+    print_grid_units(
+        schematic_units["total"], main_city_units, schematic_ships, ships_available
+    )
+    if success is False:
+        print(
+            
+                "\nYou do not have all the units needed to start this attack sequence, you want to continue executing the attack only as far as possible? [Y/n]"
+            
+        )
+        if read(values=["y", "Y", "n", "N"], default="y") in ["n", "N"]:
+            return None
+
+    banner()
+    need_float_city = check_need_float_city(schematic)
+    float_city = None
+    if need_float_city is True:
+        float_city = choose_float_city(session, island)
+        if float_city is None:
+            return None
+
+    return {
+        "session": session,
+        "island": island,
+        "city": city,
+        "float_city": float_city,
+        "schematic": schematic,
+        "units_data": units_data,
+        "ship_capacity": ship_capacity,
+    }

--- a/ikabot/function/autoPirate.py
+++ b/ikabot/function/autoPirate.py
@@ -33,6 +33,8 @@ except Exception:
     _logger = logging.getLogger(__name__)
 
 
+from ikabot.helpers.decorators import configurator, task
+
 def extract_captcha_image(html):
     """Extract the pirates captcha PNG bytes from the capture response.
 
@@ -69,114 +71,25 @@ def extract_captcha_image(html):
             return None
     return None
 
-
-def autoPirate(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    banner()
-    try:        
-
-        if not (PIRATE_DECAPTCHA_LOCAL and LOCAL_DECAPTCHA):
-            print("💡 TIP: You can process captchas locally! Run `pip install onnxruntime` to move inference to your client.")
-            print("This feature is not available if you are using the precombile binary for Windows!\n\n")
-            print("{}⚠️ USING THIS FEATURE WILL EXPOSE YOUR IP ADDRESS TO A THIRD PARTY FOR CAPTCHA SOLVING ⚠️{}\n\n".format(bcolors.WARNING, bcolors.ENDC))
-        else:
-            print("{}[SUCCESS]{} You are using local decaptcha!\n\n".format(bcolors.GREEN, bcolors.ENDC))
-    
-        print("How many pirate missions should I do? (min = 1)")
-        pirateCount = read(min=1, digit=True)
-        print("Should I schedule pirate missions by the time of day? (y/N)")
-        scheduleInput = read(values=["y", "Y", "n", "N", ""])
-        if scheduleInput.lower() == "y":
-            pirateSchedule = True
-            print(
-                """Which pirate mission should I do at daytime? (Default mission)
-        (1) 2m 30s
-        (2) 7m 30s
-        (3) 15m
-        (4) 30m
-        (5) 1h
-        (6) 2h
-        (7) 4h
-        (8) 8h
-        (9) 16h
-        """
-            )
-            pirateMissionDayChoice = read(min=1, max=9, digit=True)
-            print(
-                """At which hours should I operate at daytime? (Default: 9 hours from 10 till 18)
-            """
-            )
-            print("From: ")
-            dayStart = read()
-            if dayStart == "":
-                dayStart = 10
-            else:
-                dayStart = int(dayStart)
-
-            print("Till: ")
-            dayEnd = read()
-            if dayEnd == "":
-                dayEnd = 18
-            else:
-                dayEnd = int(dayEnd)
-
-            print(
-                """Which pirate mission should I do at night time?
-            (1) 2m 30s
-            (2) 7m 30s
-            (3) 15m
-            (4) 30m
-            (5) 1h
-            (6) 2h
-            (7) 4h
-            (8) 8h
-            (9) 16h
-            """
-            )
-            pirateMissionNightChoice = read(min=1, max=9, digit=True)
-
-            print(
-                """At which hours should I operate at night time? (Default: 15 hours from 19 till 9): 
-            """
-            )
-            print("From: ")
-            nightStart = read()
-            if nightStart == "":
-                nightStart = 19
-            else:
-                nightStart = int(nightStart)
-
-            print("Till: ")
-            nightEnd = read()
-            if nightEnd == "":
-                nightEnd = 9
-            else:
-                nightEnd = int(nightEnd)
-        else:
-            pirateSchedule = False
-            print(
-                """Which pirate mission should I do?
-        (1) 2m 30s
-        (2) 7m 30s
-        (3) 15m
-        (4) 30m
-        (5) 1h
-        (6) 2h
-        (7) 4h
-        (8) 8h
-        (9) 16h
-        """
-            )
-            pirateMissionChoice = read(min=1, max=9, digit=True)
+@task("autoPirate")
+def do_pirate_missions(
+    session,
+    pirateCount,
+    pirateSchedule,
+    pirateMissionChoice,
+    pirateMissionDayChoice,
+    pirateMissionNightChoice,
+    dayStart,
+    dayEnd,
+    nightStart,
+    nightEnd,
+    autoConvert,
+    convertPerMission,
+    maxRandomWaitingTime,
+    piracyCities
+):
+    while pirateCount > 0:
+        session.setStatus("Pirating for " + str(pirateCount) + " more runs")
         if pirateSchedule == True:
             current_hour = int(time.strftime("%H"))
             if current_hour >= dayStart and current_hour <= dayEnd:
@@ -185,71 +98,27 @@ def autoPirate(session, event, stdin_fd, predetermined_input):
                 pirateMissionChoice = pirateMissionNightChoice
             else:
                 pirateMissionChoice = pirateMissionDayChoice
-        print(
-            "Do you want me to automatically convert capture points to crew strength? (Y|N)"
-        )
-        autoConvert = read(values=["y", "Y", "n", "N"])
-        if autoConvert.lower() == "y":
-            print(
-                'How many points should I convert every time I do a mission? (Type "all" to convert all points at once)'
-            )
-            convertPerMission = read(min=0, additionalValues=["all"], digit=True)
-        print(
-            "Enter a maximum additional random waiting time between missions in seconds. (min = 0)"
-        )
-        maxRandomWaitingTime = read(min=0, digit=True)
-        piracyCities = getPiracyCities(session, pirateMissionChoice)
+        pirateCount -= 1
+        piracyCities = getPiracyCities(
+            session, pirateMissionChoice
+        )  # this is done again inside the loop in case the user destroys / creates another pirate fortress while this module is running
         if piracyCities == []:
-            print(
-                "You do not have any city with a pirate fortress capable of executing this mission!"
+            raise Exception(
+                "No city with pirate fortress capable of executing selected mission"
             )
-            enter()
-            event.set()
-            return
-
-        print(
-            "YAAAAAR!"
-        )  # get data for options such as auto-convert to crew strength, time intervals, number of piracy attempts... ^^
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    try:
-        while pirateCount > 0:
-            session.setStatus("Pirating for " + str(pirateCount) + " more runs")
-            if pirateSchedule == True:
-                current_hour = int(time.strftime("%H"))
-                if current_hour >= dayStart and current_hour <= dayEnd:
-                    pirateMissionChoice = pirateMissionDayChoice
-                elif current_hour >= nightStart or current_hour <= nightEnd:
-                    pirateMissionChoice = pirateMissionNightChoice
-                else:
-                    pirateMissionChoice = pirateMissionDayChoice
-            pirateCount -= 1
-            piracyCities = getPiracyCities(
-                session, pirateMissionChoice
-            )  # this is done again inside the loop in case the user destroys / creates another pirate fortress while this module is running
-            if piracyCities == []:
-                raise Exception(
-                    "No city with pirate fortress capable of executing selected mission"
-                )
-            html = session.post(
-                city_url + str(piracyCities[0]["id"])
-            )  # this is needed because for some reason you need to look at the town where you are sending a request from in the line below, before you send that request
-            if (
-                '"showPirateFortressShip":0' in html
-            ):  # this is in case the user has manually run a capture run, in that case, there is no need to wait 150secs instead we can check every 5
-                url = "view=pirateFortress&cityId={}&position=17&backgroundView=city&currentCityId={}&actionRequest={}&ajax=1".format(
-                    piracyCities[0]["id"], piracyCities[0]["id"], actionRequest
-                )
-                html = session.post(url)
-                wait(getCurrentMissionWaitingTime(html), maxRandomWaitingTime)
-                pirateCount += 1  # don't count this as an iteration of the loop
-                continue
+        html = session.post(
+            city_url + str(piracyCities[0]["id"])
+        )  # this is needed because for some reason you need to look at the town where you are sending a request from in the line below, before you send that request
+        if (
+            '"showPirateFortressShip":0' in html
+        ):  # this is in case the user has manually run a capture run, in that case, there is no need to wait 150secs instead we can check every 5
+            url = "view=pirateFortress&cityId={}&position=17&backgroundView=city&currentCityId={}&actionRequest={}&ajax=1".format(
+                piracyCities[0]["id"], piracyCities[0]["id"], actionRequest
+            )
+            html = session.post(url)
+            wait(getCurrentMissionWaitingTime(html), maxRandomWaitingTime)
+            pirateCount += 1  # don't count this as an iteration of the loop
+            continue
 
             url = "action=PiracyScreen&function=capture&buildingLevel={0}&view=pirateFortress&cityId={1}&position=17&activeTab=tabBootyQuest&backgroundView=city&currentCityId={1}&templateView=pirateFortress&actionRequest={2}&ajax=1".format(
                 piracyMissionToBuildingLevel[pirateMissionChoice],
@@ -334,12 +203,170 @@ def autoPirate(session, event, stdin_fd, predetermined_input):
                 convertCapturePoints(session, piracyCities, convertPerMission)
             wait(piracyMissionWaitingTime[pirateMissionChoice], maxRandomWaitingTime)
 
-    except Exception:
-        info = ""
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-        event.set()
-        return
+@configurator
+def autoPirate(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+
+    if not (PIRATE_DECAPTCHA_LOCAL and LOCAL_DECAPTCHA):
+        print("💡 TIP: You can process captchas locally! Run `pip install onnxruntime` to move inference to your client.")
+        print("This feature is not available if you are using the precombile binary for Windows!\n\n")
+        print("{}⚠️ USING THIS FEATURE WILL EXPOSE YOUR IP ADDRESS TO A THIRD PARTY FOR CAPTCHA SOLVING ⚠️{}\n\n".format(bcolors.WARNING, bcolors.ENDC))
+    else:
+        print("{}[SUCCESS]{} You are using local decaptcha!\n\n".format(bcolors.GREEN, bcolors.ENDC))
+
+    print("How many pirate missions should I do? (min = 1)")
+    pirateCount = read(min=1, digit=True)
+    print("Should I schedule pirate missions by the time of day? (y/N)")
+    scheduleInput = read(values=["y", "Y", "n", "N", ""])
+    pirateMissionDayChoice = None
+    pirateMissionNightChoice = None
+    dayStart = None
+    dayEnd = None
+    nightStart = None
+    nightEnd = None
+    pirateMissionChoice = None
+
+    if scheduleInput.lower() == "y":
+        pirateSchedule = True
+        print(
+            """Which pirate mission should I do at daytime? (Default mission)
+    (1) 2m 30s
+    (2) 7m 30s
+    (3) 15m
+    (4) 30m
+    (5) 1h
+    (6) 2h
+    (7) 4h
+    (8) 8h
+    (9) 16h
+    """
+        )
+        pirateMissionDayChoice = read(min=1, max=9, digit=True)
+        print(
+            """At which hours should I operate at daytime? (Default: 9 hours from 10 till 18)
+        """
+        )
+        print("From: ")
+        dayStart = read()
+        if dayStart == "":
+            dayStart = 10
+        else:
+            dayStart = int(dayStart)
+
+        print("Till: ")
+        dayEnd = read()
+        if dayEnd == "":
+            dayEnd = 18
+        else:
+            dayEnd = int(dayEnd)
+
+        print(
+            """Which pirate mission should I do at night time?
+        (1) 2m 30s
+        (2) 7m 30s
+        (3) 15m
+        (4) 30m
+        (5) 1h
+        (6) 2h
+        (7) 4h
+        (8) 8h
+        (9) 16h
+        """
+        )
+        pirateMissionNightChoice = read(min=1, max=9, digit=True)
+
+        print(
+            """At which hours should I operate at night time? (Default: 15 hours from 19 till 9): 
+        """
+        )
+        print("From: ")
+        nightStart = read()
+        if nightStart == "":
+            nightStart = 19
+        else:
+            nightStart = int(nightStart)
+
+        print("Till: ")
+        nightEnd = read()
+        if nightEnd == "":
+            nightEnd = 9
+        else:
+            nightEnd = int(nightEnd)
+    else:
+        pirateSchedule = False
+        print(
+            """Which pirate mission should I do?
+    (1) 2m 30s
+    (2) 7m 30s
+    (3) 15m
+    (4) 30m
+    (5) 1h
+    (6) 2h
+    (7) 4h
+    (8) 8h
+    (9) 16h
+    """
+        )
+        pirateMissionChoice = read(min=1, max=9, digit=True)
+    if pirateSchedule == True:
+        current_hour = int(time.strftime("%H"))
+        if current_hour >= dayStart and current_hour <= dayEnd:
+            pirateMissionChoice = pirateMissionDayChoice
+        elif current_hour >= nightStart or current_hour <= nightEnd:
+            pirateMissionChoice = pirateMissionNightChoice
+        else:
+            pirateMissionChoice = pirateMissionDayChoice
+    print(
+        "Do you want me to automatically convert capture points to crew strength? (Y|N)"
+    )
+    autoConvert = read(values=["y", "Y", "n", "N"])
+    convertPerMission = 0
+    if autoConvert.lower() == "y":
+        print(
+            'How many points should I convert every time I do a mission? (Type "all" to convert all points at once)'
+        )
+        convertPerMission = read(min=0, additionalValues=["all"], digit=True)
+    print(
+        "Enter a maximum additional random waiting time between missions in seconds. (min = 0)"
+    )
+    maxRandomWaitingTime = read(min=0, digit=True)
+    piracyCities = getPiracyCities(session, pirateMissionChoice)
+    if piracyCities == []:
+        print(
+            "You do not have any city with a pirate fortress capable of executing this mission!"
+        )
+        enter()
+        return None
+
+    print(
+        "YAAAAAR!"
+    )  # get data for options such as auto-convert to crew strength, time intervals, number of piracy attempts... ^^
+    enter()
+    
+    return {
+        "session": session,
+        "pirateCount": pirateCount,
+        "pirateSchedule": pirateSchedule,
+        "pirateMissionChoice": pirateMissionChoice,
+        "pirateMissionDayChoice": pirateMissionDayChoice,
+        "pirateMissionNightChoice": pirateMissionNightChoice,
+        "dayStart": dayStart,
+        "dayEnd": dayEnd,
+        "nightStart": nightStart,
+        "nightEnd": nightEnd,
+        "autoConvert": autoConvert,
+        "convertPerMission": convertPerMission,
+        "maxRandomWaitingTime": maxRandomWaitingTime,
+        "piracyCities": piracyCities
+    }
 
 
 def _is_png_bytes(image):

--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -15,7 +15,7 @@ from ikabot.helpers.market import *
 from ikabot.helpers.naval import getTotalShips
 from ikabot.helpers.pedirInfo import getIdsOfCities, read
 from ikabot.helpers.planRoutes import waitForArrival
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.resources import *
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import addThousandSeparator, getDateTime
@@ -189,134 +189,6 @@ def filterOffers(offers):
     return [offer for offer in offers if offer[key] == seller], seller
 
 
-def buyResources(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-
-        # get all the cities with a store
-        commercial_cities = getCommercialCities(session)
-        if len(commercial_cities) == 0:
-            print("There is no store build")
-            enter()
-            event.set()
-            return
-
-        # choose which city to buy from
-        if len(commercial_cities) == 1:
-            city = commercial_cities[0]
-        else:
-            city = chooseCommertialCity(commercial_cities)
-            banner()
-
-        # choose resource to buy
-        resource = chooseResource(session, city)
-        banner()
-
-        # get all the offers of the chosen resource from the chosen city
-        offers = getOffers(session, city)
-        offers.sort(key=lambda o: o["precio"])
-        if len(offers) == 0:
-            print("There are no offers available.")
-            enter()
-            event.set()
-            return
-
-        # let the user buy from one seller only
-        (offers, seller) = filterOffers(offers)
-        banner()
-
-        # display offers to the user
-        total_price = 0
-        total_amount = 0
-        for offer in offers:
-            amount = offer["amountAvailable"]
-            price = offer["precio"]
-            cost = amount * price
-            print(
-                "seller:{} ({})".format(
-                    offer["jugadorAComprar"], offer["ciudadDestino"]
-                )
-            )
-            print("amount:{}".format(addThousandSeparator(amount)))
-            print("price :{:d}".format(price))
-            print("cost  :{}".format(addThousandSeparator(cost)))
-            print("")
-            total_price += cost
-            total_amount += amount
-
-        # ask how much to buy
-        print(
-            "Total amount available to purchase: {}, for {}".format(
-                addThousandSeparator(total_amount), addThousandSeparator(total_price)
-            )
-        )
-        available = city["freeSpaceForResources"][resource]
-        if available < total_amount:
-            print(
-                "You just can buy {} due to storing capacity".format(
-                    addThousandSeparator(available)
-                )
-            )
-            total_amount = available
-        print("")
-        amount_to_buy = read(
-            msg="How much do you want to buy?: ", min=0, max=total_amount
-        )
-        if amount_to_buy == 0:
-            event.set()
-            return
-
-        # calculate the total cost
-        (gold, __) = getGold(session, city)
-        total_cost = calculateCost(offers, amount_to_buy)
-
-        print(
-            "\nCurrent gold: {}.\nTotal cost  : {}.\nFinal gold  : {}.".format(
-                addThousandSeparator(gold),
-                addThousandSeparator(total_cost),
-                addThousandSeparator(gold - total_cost),
-            )
-        )
-        print("Proceed? [Y/n]")
-        rta = read(values=["y", "Y", "n", "N", ""])
-        if rta.lower() == "n":
-            event.set()
-            return
-
-        print("It will be purchased {}".format(addThousandSeparator(amount_to_buy)))
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI will buy {} from {} to {}\n".format(
-        addThousandSeparator(amount_to_buy), materials_names[resource], city["cityName"]
-    )
-    if seller is not None:
-        info += "Buying from {} only\n".format(seller)
-    setInfoSignal(session, info)
-    try:
-        do_it(session, city, offers, amount_to_buy)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
 def buy(session, city, offer, amount_to_buy, ships_available, ship_capacity):
     """
     Parameters
@@ -389,6 +261,7 @@ def buy(session, city, offer, amount_to_buy, ships_available, ship_capacity):
     )
 
 
+@task("buyResources")
 def do_it(session, city, offers, amount_to_buy):
     """
     Parameters
@@ -398,6 +271,10 @@ def do_it(session, city, offers, amount_to_buy):
     offers : list[dict]
     amount_to_buy : int
     """
+    info = "\nI will buy {} {} to {}\n".format(
+        addThousandSeparator(amount_to_buy), offers[0]['tipo'] if len(offers) > 0 else "resources", city["cityName"]
+    )
+    setInfoSignal(session, info)
     ship_capacity, freighter_capacity = getShipCapacity(session)
     while True:
         for offer in offers:
@@ -414,3 +291,105 @@ def do_it(session, city, offers, amount_to_buy):
             buy(session, city, offer, buy_amount, ships_available, ship_capacity)
             # start from the beginning again, so that we always buy from the cheapest offers fisrt
             break
+@configurator
+def buyResources(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+
+    # get all the cities with a store
+    commercial_cities = getCommercialCities(session)
+    if len(commercial_cities) == 0:
+        print("There is no store build")
+        enter()
+        return None
+
+    # choose which city to buy from
+    if len(commercial_cities) == 1:
+        city = commercial_cities[0]
+    else:
+        city = chooseCommertialCity(commercial_cities)
+        banner()
+
+    # choose resource to buy
+    resource = chooseResource(session, city)
+    banner()
+
+    # get all the offers of the chosen resource from the chosen city
+    offers = getOffers(session, city)
+    offers.sort(key=lambda o: o["precio"])
+    if len(offers) == 0:
+        print("There are no offers available.")
+        enter()
+        return None
+
+    # let the user buy from one seller only
+    (offers, seller) = filterOffers(offers)
+    banner()
+
+    # display offers to the user
+    total_price = 0
+    total_amount = 0
+    for offer in offers:
+        amount = offer["amountAvailable"]
+        price = offer["precio"]
+        cost = amount * price
+        print(
+            "seller:{} ({})".format(
+                offer["jugadorAComprar"], offer["ciudadDestino"]
+            )
+        )
+        print("amount:{}".format(addThousandSeparator(amount)))
+        print("price :{:d}".format(price))
+        print("cost  :{}".format(addThousandSeparator(cost)))
+        print("")
+        total_price += cost
+        total_amount += amount
+
+    # ask how much to buy
+    print(
+        "Total amount available to purchase: {}, for {}".format(
+            addThousandSeparator(total_amount), addThousandSeparator(total_price)
+        )
+    )
+    available = city["freeSpaceForResources"][resource]
+    if available < total_amount:
+        print(
+            "You just can buy {} due to storing capacity".format(
+                addThousandSeparator(available)
+            )
+        )
+        total_amount = available
+    print("")
+    amount_to_buy = read(
+        msg="How much do you want to buy?: ", min=0, max=total_amount
+    )
+    if amount_to_buy == 0:
+        return None
+
+    # calculate the total cost
+    (gold, __) = getGold(session, city)
+    total_cost = calculateCost(offers, amount_to_buy)
+
+    print(
+        "\nCurrent gold: {}.\nTotal cost  : {}.\nFinal gold  : {}.".format(
+            addThousandSeparator(gold),
+            addThousandSeparator(total_cost),
+            addThousandSeparator(gold - total_cost),
+        )
+    )
+    print("Proceed? [Y/n]")
+    rta = read(values=["y", "Y", "n", "N", ""])
+    if rta.lower() == "n":
+        return None
+
+    print("It will be purchased {}".format(addThousandSeparator(amount_to_buy)))
+    enter()
+    return {"session": session, "city": city, "offers": offers, "amount_to_buy": amount_to_buy}
+

--- a/ikabot/function/consolidateResources.py
+++ b/ikabot/function/consolidateResources.py
@@ -11,7 +11,7 @@ from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import banner
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.planRoutes import executeRoutes, splitCargoBetweenFleets
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.resources import *
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import addThousandSeparator
@@ -27,123 +27,7 @@ SHIP_TYPE_NAMES = {
     SHIP_TYPE_BOTH: 'Trade ships and freighters',
 }
 
-def consolidateResources(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-
-        citiesIds, __ = getIdsOfCities(session)
-        if len(citiesIds) == 0:
-            event.set()
-            return
-
-        if len(citiesIds) == 1:
-            print('You need at least two cities to consolidate resources.')
-            event.set()
-            return
-
-        banner()
-        print('What type of ships do you want to use? (Default: Trade ships)')
-        print('(1) Trade ships')
-        print('(2) Freighters')
-        print('(3) Both')
-        shipType = read(min=1, max=3, digit=True, empty=True)
-        if shipType == '':
-            shipType = SHIP_TYPE_TRADE_SHIPS
-
-        banner()
-        source_msg = 'Select source cities to send resources from:'
-        sourceCities, sourceCitiesDict = ignoreCities(session, msg=source_msg)
-        
-        if sourceCities is None:
-            event.set()
-            return
-
-        banner()
-        print('Select destination cities to receive resources:')
-        destinationCity = chooseCity(session)
-
-        if destinationCity is None:
-            event.set()
-            return
-        
-        destination_id_str = str(destinationCity['id'])
-        if destination_id_str in sourceCities:
-            sourceCities.remove(destination_id_str)
-            del sourceCitiesDict[destination_id_str]
-
-        banner()
-        print('Define resource limits to keep:')
-    
-        limits = []
-        
-        for i, resource in enumerate(materials_names):
-            prompt = 'Enter maximum {} to keep (skip to keep everything): '.format(resource)
-            resourceLimit = read(msg=prompt, min=-1, default=-1)
-            limits.append(resourceLimit)
-        
-        banner()
-        print('Define how often to execute the process in hours (min - 1 hour):')
-        intervalInHours = read(min=1, default=1)
-
-        banner()
-        print(('The process will transfer everything above specified limits:'))
-        for i, resource in enumerate(materials_names):
-            if limits[i] == -1:
-                print(('- Keep all {}').format(resource))
-            else:
-                print(('- Keep up to {} {} and send excess').format(addThousandSeparator(limits[i]), resource))
-        
-        source_city_names_str = ', '.join([city['name'] for city in sourceCitiesDict.values()])
-        print(('\nFrom {} to {} every {} hours').format(
-            source_city_names_str, 
-            destinationCity['name'], 
-            intervalInHours,
-        ))
-        print(('Using {}').format(SHIP_TYPE_NAMES[shipType].lower()))
-
-        print("\nProceed? [Y/n]")
-        rta = read(values=["y", "Y", "n", "N", ""])
-        if rta.lower() == "n":
-            event.set()
-            return
-
-        enter()
-
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()  # this is where we give back control to main process
-
-    info = 'Consolidate resources from {} to {} every {:d} hours using {}'.format(source_city_names_str, destinationCity['name'], intervalInHours, SHIP_TYPE_NAMES[shipType].lower())
-    setInfoSignal(session, info)
-
-    nextExecutionTime = datetime.datetime.now() + datetime.timedelta(hours=intervalInHours)
-
-    session.setStatus(
-        f" {source_city_names_str} -> {destinationCity['name']} | Next at {getDateTime(nextExecutionTime.timestamp())}"
-    )
-
-    try:
-        do_it(session, limits, sourceCities, destinationCity['id'], intervalInHours, shipType)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
+@task("consolidateResources")
 def do_it(session, limits, sourceCityIds, destinationCityId, intervalInHours, shipType=SHIP_TYPE_TRADE_SHIPS):
     """
     Parameters
@@ -156,6 +40,11 @@ def do_it(session, limits, sourceCityIds, destinationCityId, intervalInHours, sh
     shipType : int
         one of SHIP_TYPE_TRADE_SHIPS, SHIP_TYPE_FREIGHTERS or SHIP_TYPE_BOTH
     """
+    source_city_names = [getCity(session.get(city_url + str(city_id)))['name'] for city_id in sourceCityIds]
+    source_city_names_str = ', '.join(source_city_names)
+    destinationCityName = getCity(session.get(city_url + str(destinationCityId)))['name']
+    info = 'Consolidate resources from {} to {} every {:d} hours using {}'.format(source_city_names_str, destinationCityName, intervalInHours, SHIP_TYPE_NAMES[shipType].lower())
+    setInfoSignal(session, info)
 
     firstRun = True
     nextRunTime = datetime.datetime.now()
@@ -235,3 +124,89 @@ def do_it(session, limits, sourceCityIds, destinationCityId, intervalInHours, sh
         firstRun = False
 
         time.sleep(60 * 60)
+@configurator
+def consolidateResources(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+
+    citiesIds, __ = getIdsOfCities(session)
+    if len(citiesIds) == 0:
+        return None
+
+    if len(citiesIds) == 1:
+        print('You need at least two cities to consolidate resources.')
+        return None
+
+    banner()
+    print('What type of ships do you want to use? (Default: Trade ships)')
+    print('(1) Trade ships')
+    print('(2) Freighters')
+    print('(3) Both')
+    shipType = read(min=1, max=3, digit=True, empty=True)
+    if shipType == '':
+        shipType = SHIP_TYPE_TRADE_SHIPS
+
+    banner()
+    source_msg = 'Select source cities to send resources from:'
+    sourceCities, sourceCitiesDict = ignoreCities(session, msg=source_msg)
+    
+    if sourceCities is None:
+        return None
+
+    banner()
+    print('Select destination cities to receive resources:')
+    destinationCity = chooseCity(session)
+
+    if destinationCity is None:
+        return None
+    
+    destination_id_str = str(destinationCity['id'])
+    if destination_id_str in sourceCities:
+        sourceCities.remove(destination_id_str)
+        del sourceCitiesDict[destination_id_str]
+
+    banner()
+    print('Define resource limits to keep:')
+    
+    limits = []
+    
+    for i, resource in enumerate(materials_names):
+        prompt = 'Enter maximum {} to keep (skip to keep everything): '.format(resource)
+        resourceLimit = read(msg=prompt, min=-1, default=-1)
+        limits.append(resourceLimit)
+    
+    banner()
+    print('Define how often to execute the process in hours (min - 1 hour):')
+    intervalInHours = read(min=1, default=1)
+
+    banner()
+    print(('The process will transfer everything above specified limits:'))
+    for i, resource in enumerate(materials_names):
+        if limits[i] == -1:
+            print(('- Keep all {}').format(resource))
+        else:
+            print(('- Keep up to {} {} and send excess').format(addThousandSeparator(limits[i]), resource))
+    
+    source_city_names_str = ', '.join([city['name'] for city in sourceCitiesDict.values()])
+    print(('\nFrom {} to {} every {} hours').format(
+        source_city_names_str, 
+        destinationCity['name'], 
+        intervalInHours,
+    ))
+    print(('Using {}').format(SHIP_TYPE_NAMES[shipType].lower()))
+
+    print("\nProceed? [Y/n]")
+    rta = read(values=["y", "Y", "n", "N", ""])
+    if rta.lower() == "n":
+        return None
+
+    enter()
+    return {"session": session, "limits": limits, "sourceCityIds": list(sourceCitiesDict.keys()), "destinationCityId": destinationCity["id"], "intervalInHours": intervalInHours, "shipType": shipType}
+

--- a/ikabot/function/constructBuilding.py
+++ b/ikabot/function/constructBuilding.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -44,6 +45,7 @@ def splitBuildingBlocks(html):
     return blocks
 
 
+@configurator
 def constructBuilding(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -53,8 +55,6 @@ def constructBuilding(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
 

--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -21,15 +21,11 @@ from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.planRoutes import *
-from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.resources import getAvailableResources
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import *
 from ikabot.web.session import normal_get
-
-sendResources = True
-expand = True
-thread = None
+from ikabot.helpers.decorators import configurator, task
 
 
 def waitForConstruction(session, city_id, final_lvl):
@@ -422,10 +418,8 @@ def chooseResourceProviders(session, cities_ids, cities, city_id, resource, miss
     resource : int
     missing : int
     """
-    global sendResources
-    sendResources = True
-    global expand
-    expand = True
+    send_resources_flag = True
+    expand_flag = True
 
     banner()
     print("From what cities obtain {}?".format(materials_names[resource].lower()))
@@ -468,7 +462,7 @@ def chooseResourceProviders(session, cities_ids, cities, city_id, resource, miss
         origin_cities.append(city)
         # if we have enough resources, return
         if total_available >= missing:
-            return origin_cities
+            return origin_cities, send_resources_flag, expand_flag
 
     # if we reach this part, there are not enough resources to expand the building
     print("\nThere are not enough resources.")
@@ -477,69 +471,56 @@ def chooseResourceProviders(session, cities_ids, cities, city_id, resource, miss
         print("\nSend the resources anyway? [Y/n]")
         choice = read(values=["y", "Y", "n", "N", ""])
         if choice.lower() == "n":
-            sendResources = False
+            send_resources_flag = False
 
     print("\nTry to expand the building anyway? [y/N]")
     choice = read(values=["y", "Y", "n", "N", ""])
     if choice.lower() == "n" or choice == "":
-        expand = False
+        expand_flag = False
 
-    return origin_cities
+    return origin_cities, send_resources_flag, expand_flag
 
 
-def sendResourcesMenu(session, city_id, missing, useFreighters=False, useRounding=False):
+def sendResourcesMenu(session, city_id, missing):
     """
     Parameters
     ----------
     session : ikabot.web.session.Session
     city_id : int
     missing : list[int, int]
-    useFreighters : bool
-    useRounding : bool
     """
-    global thread
     cities_ids, cities = getIdsOfCities(session)
     origins = {}
+    
+    send_resources_flag = True
+    expand_flag = True
+    
     # for each missing resource, choose providers
     for resource in range(len(missing)):
         if missing[resource] <= 0:
             continue
 
-        origin_cities = chooseResourceProviders(
+        origin_cities, current_send_resources, current_expand = chooseResourceProviders(
             session, cities_ids, cities, city_id, resource, missing[resource]
         )
-        if sendResources is False and expand:
+        send_resources_flag = current_send_resources
+        expand_flag = current_expand
+        if send_resources_flag is False and expand_flag:
             print("\nThe building will be expanded if possible.")
             enter()
-            return
-        elif sendResources is False:
-            return
+            return None, expand_flag
+        elif send_resources_flag is False:
+            return None, expand_flag
         origins[resource] = origin_cities
 
-    if expand:
-        print(
-
-                "\nThe resources will be sent and the building will be expanded if possible."
-
-        )
+    if expand_flag:
+        print("\nThe resources will be sent and the building will be expanded if possible.")
     else:
         print("\nThe resources will be sent.")
 
     enter()
 
-    # create a new thread to send the resources
-    thread = threading.Thread(
-        target=sendResourcesNeeded,
-        args=(
-            session,
-            city_id,
-            origins,
-            missing,
-            useFreighters,
-            useRounding,
-        ),
-    )
-    thread.start()
+    return origins, expand_flag
 
 
 def getBuildingsToExpand(session, cityId):
@@ -628,6 +609,42 @@ def checkhash(url):
     return material
 
 
+@task("constructionList")
+def do_it(session, city_id, city_name, buildings, shipments, expand_overall, wait_resources):
+    info = "\nUpgrade building\n"
+    building_log_name = buildings[0]["name"] if len(buildings) == 1 else "Multiple buildings"
+    info = info + "City: {}\nBuilding: {}".format(city_name, building_log_name)
+    setInfoSignal(session, info)
+    
+    threads = []
+    for shipment in shipments:
+        t = threading.Thread(
+            target=sendResourcesNeeded,
+            args=(
+                session,
+                city_id,
+                shipment["origins"],
+                shipment["missing"],
+                shipment["useFreighters"],
+                shipment["useRounding"],
+            ),
+        )
+        t.start()
+        threads.append(t)
+
+    try:
+        if expand_overall:
+            for building in buildings:
+                expandBuilding(session, city_id, building, wait_resources)
+        else:
+            for t in threads:
+                t.join()
+    except Exception as e:
+        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
+        sendToBot(session, msg)
+
+
+@configurator
 def constructionList(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -637,168 +654,156 @@ def constructionList(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        global expand
-        global sendResources
-        expand = True
-        sendResources = True
+    banner()
+    wait_resources = False
+    print("In which city do you want to expand buildings?")
+    city = chooseCity(session)
+    cityId = city["id"]
+    buildings = getBuildingsToExpand(session, cityId)
+    if buildings is None or len(buildings) == 0:
+        return None
 
-        banner()
-        wait_resources = False
-        print("In which city do you want to expand buildings?")
-        city = chooseCity(session)
-        cityId = city["id"]
-        buildings = getBuildingsToExpand(session, cityId)
-        if buildings is None or len(buildings) == 0:
-            event.set()
-            return
+    #simulated resources
+    simulated_resources = list(city["availableResources"])
+    simulated_reducers = getCostsReducers(city)
 
-        #simulated resources
-        simulated_resources = list(city["availableResources"])
-        simulated_reducers = getCostsReducers(city)
+    for b in city["position"]:
+        if b["name"] != "empty" and b.get("isBusy", False):
+            if b["building"] == "carpentering":
+                simulated_reducers[0] = min(50, simulated_reducers[0] + 1)
+            elif b["building"] == "vineyard":
+                simulated_reducers[1] = min(50, simulated_reducers[1] + 1)
+            elif b["building"] == "architect":
+                simulated_reducers[2] = min(50, simulated_reducers[2] + 1)
+            elif b["building"] == "optician":
+                simulated_reducers[3] = min(50, simulated_reducers[3] + 1)
+            elif b["building"] == "fireworker":
+                simulated_reducers[4] = min(50, simulated_reducers[4] + 1)
 
-        for b in city["position"]:
-            if b["name"] != "empty" and b.get("isBusy", False):
-                if b["building"] == "carpentering":
-                    simulated_reducers[0] = min(50, simulated_reducers[0] + 1)
-                elif b["building"] == "vineyard":
-                    simulated_reducers[1] = min(50, simulated_reducers[1] + 1)
-                elif b["building"] == "architect":
-                    simulated_reducers[2] = min(50, simulated_reducers[2] + 1)
-                elif b["building"] == "optician":
-                    simulated_reducers[3] = min(50, simulated_reducers[3] + 1)
-                elif b["building"] == "fireworker":
-                    simulated_reducers[4] = min(50, simulated_reducers[4] + 1)
+    # NewList - Only Accepted
+    confirmed_buildings = []
+    shipments = []
+    expand_overall = True
 
-        # NewList - Only Accepted
-        confirmed_buildings = []
+    # Sequentially upgrade each building
+    for building in buildings:
+        current_level = building["level"]
+        if building["isBusy"]:
+            current_level += 1
+        final_level = building["upgradeTo"]
 
-        # Sequentially upgrade each building
-        for building in buildings:
-            current_level = building["level"]
-            if building["isBusy"]:
-                current_level += 1
-            final_level = building["upgradeTo"]
+        current_reducers = list(simulated_reducers)
 
-            current_reducers = list(simulated_reducers)
+        # calculate the resources that are needed
+        resourcesNeeded = getResourcesNeeded(
+            session, city, building, current_level, final_level, current_reducers
+        )
 
-            # calculate the resources that are needed
-            resourcesNeeded = getResourcesNeeded(
-                session, city, building, current_level, final_level, current_reducers
-            )
+        if -2 in resourcesNeeded:
+            print(f"\nSkipping {building['name']}.\n")
+            continue
 
-            if -2 in resourcesNeeded:
-                print(f"\nSkipping {building['name']}.\n")
-                continue
+        if -1 in resourcesNeeded:
+            return None
 
-            if -1 in resourcesNeeded:
-                event.set()
-                return
+        missing = [0] * len(materials_names)
+        for i in range(len(materials_names)):
+            if simulated_resources[i] < resourcesNeeded[i]:
+                missing[i] = resourcesNeeded[i] - simulated_resources[i]
 
-            missing = [0] * len(materials_names)
+        # show missing resources to the user
+        if sum(missing) > 0:
+            print("\nMaterials needed for {} (lv {:d} -> {:d}):".format(building["name"], current_level, final_level))
+            for i, name in enumerate(materials_names):
+                amount = resourcesNeeded[i]
+                if amount == 0:
+                    continue
+                print("- {}: {}".format(name, addThousandSeparator(max(0, amount))))
+            print("")
+
+            print("Missing:")
             for i in range(len(materials_names)):
-                if simulated_resources[i] < resourcesNeeded[i]:
-                    missing[i] = resourcesNeeded[i] - simulated_resources[i]
+                if missing[i] <= 0:
+                    continue
+                name = materials_names[i].lower()
+                print("{} of {}".format(addThousandSeparator(missing[i]), name))
+            print("")
 
-            # show missing resources to the user
-            if sum(missing) > 0:
-                print("\nMaterials needed for {} (lv {:d} -> {:d}):".format(building["name"], current_level, final_level))
-                for i, name in enumerate(materials_names):
-                    amount = resourcesNeeded[i]
-                    if amount == 0:
-                        continue
-                    print("- {}: {}".format(name, addThousandSeparator(max(0, amount))))
-                print("")
-
-                print("Missing:")
-                for i in range(len(materials_names)):
-                    if missing[i] <= 0:
-                        continue
-                    name = materials_names[i].lower()
-                    print("{} of {}".format(addThousandSeparator(missing[i]), name))
-                print("")
-
-                # if the user wants, send the resources from the selected cities
-                print("Automatically transport resources? [Y/n]")
-                rta = read(values=["y", "Y", "n", "N", ""])
-                if rta.lower() == "n":
-                    print("Proceed anyway? [Y/n]")
-                    rta = read(values=["y", "Y", "n", "N", ""])
-                    if rta.lower() == "n":
-                        print(f"\nSkipping {building['name']} due to user cancellation.\n")
-                        continue  # If it cancels, we skip it and it is NOT added to confirm_buildings
-                else:
-                    print("What type of ships do you want to use? (Default: Trade ships)")
-                    print("(1) Trade ships")
-                    print("(2) Freighters")
-                    shiptype = read(min=1, max=2, digit=True, empty=True)
-                    if shiptype == '':
-                        shiptype = 1
-                    if shiptype == 1:
-                        useFreighters = False
-                    elif shiptype == 2:
-                        useFreighters = True
-                    print("Round up transport amounts? [Y/n]")
-                    print("(amounts will be rounded up but capped at what each city can provide)")
-                    rta_round = read(values=["y", "Y", "n", "N", ""])
-                    useRounding = rta_round.lower() != "n"
-                    wait_resources = True
-                    sendResourcesMenu(session, cityId, missing, useFreighters, useRounding)
-            else:
-                print("\nMaterials needed for {} (lv {:d} -> {:d}):".format(building["name"], current_level, final_level))
-                for i, name in enumerate(materials_names):
-                    amount = resourcesNeeded[i]
-                    if amount == 0:
-                        continue
-                    print("- {}: {}".format(name, addThousandSeparator(max(0, amount))))
-                print("")
-
-                print("You have enough materials")
-                print("Proceed? [Y/n]")
+            # if the user wants, send the resources from the selected cities
+            print("Automatically transport resources? [Y/n]")
+            rta = read(values=["y", "Y", "n", "N", ""])
+            if rta.lower() == "n":
+                print("Proceed anyway? [Y/n]")
                 rta = read(values=["y", "Y", "n", "N", ""])
                 if rta.lower() == "n":
                     print(f"\nSkipping {building['name']} due to user cancellation.\n")
                     continue  # If it cancels, we skip it and it is NOT added to confirm_buildings
+            else:
+                print("What type of ships do you want to use? (Default: Trade ships)")
+                print("(1) Trade ships")
+                print("(2) Freighters")
+                shiptype = read(min=1, max=2, digit=True, empty=True)
+                if shiptype == '':
+                    shiptype = 1
+                if shiptype == 1:
+                    useFreighters = False
+                elif shiptype == 2:
+                    useFreighters = True
+                print("Round up transport amounts? [Y/n]")
+                print("(amounts will be rounded up but capped at what each city can provide)")
+                rta_round = read(values=["y", "Y", "n", "N", ""])
+                useRounding = rta_round.lower() != "n"
+                wait_resources = True
+                origins, current_expand = sendResourcesMenu(session, cityId, missing)
+                
+                if not current_expand:
+                    expand_overall = False
+                
+                if origins:
+                    shipments.append({
+                        "origins": origins,
+                        "missing": missing,
+                        "useFreighters": useFreighters,
+                        "useRounding": useRounding
+                    })
+        else:
+            print("\nMaterials needed for {} (lv {:d} -> {:d}):".format(building["name"], current_level, final_level))
+            for i, name in enumerate(materials_names):
+                amount = resourcesNeeded[i]
+                if amount == 0:
+                    continue
+                print("- {}: {}".format(name, addThousandSeparator(max(0, amount))))
+            print("")
 
-            # Save the approved building and deduct it from the simulator
-            confirmed_buildings.append(building)
-            simulated_reducers = current_reducers
+            print("You have enough materials")
+            print("Proceed? [Y/n]")
+            rta = read(values=["y", "Y", "n", "N", ""])
+            if rta.lower() == "n":
+                print(f"\nSkipping {building['name']} due to user cancellation.\n")
+                continue  # If it cancels, we skip it and it is NOT added to confirm_buildings
 
-            for i in range(len(materials_names)):
-                if simulated_resources[i] < resourcesNeeded[i]:
-                    simulated_resources[i] = 0
-                else:
-                    simulated_resources[i] -= resourcesNeeded[i]
+        # Save the approved building and deduct it from the simulator
+        confirmed_buildings.append(building)
+        simulated_reducers = current_reducers
 
-        # Replace list
-        buildings = confirmed_buildings
+        for i in range(len(materials_names)):
+            if simulated_resources[i] < resourcesNeeded[i]:
+                simulated_resources[i] = 0
+            else:
+                simulated_resources[i] -= resourcesNeeded[i]
 
-    except KeyboardInterrupt:
-        event.set()
-        return
+    # Replace list
+    buildings = confirmed_buildings
 
-    if (not buildings or len(buildings) == 0) and not thread:
-        event.set()
-        return
+    if (not buildings or len(buildings) == 0) and len(shipments) == 0:
+        return None
 
-    set_child_mode(session)
-    event.set()
-
-    building_log_name = buildings[0]["name"] if len(buildings) == 1 else "Multiple buildings"
-    info = "\nUpgrade building\n"
-    info = info + "City: {}\nBuilding: {}".format(city["cityName"], building_log_name)
-
-    setInfoSignal(session, info)
-    try:
-        if expand:
-            for building in buildings:
-                expandBuilding(session, cityId, building, wait_resources)
-        elif thread:
-            thread.join()
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "session": session,
+        "city_id": cityId,
+        "city_name": city["cityName"],
+        "buildings": buildings,
+        "shipments": shipments,
+        "expand_overall": expand_overall,
+        "wait_resources": wait_resources
+    }

--- a/ikabot/function/decaptchaConf.py
+++ b/ikabot/function/decaptchaConf.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import base64
@@ -32,6 +33,7 @@ decaptcha_test_pictures = [
 ]
 
 
+@configurator
 def decaptchaConf(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -41,8 +43,6 @@ def decaptchaConf(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     banner()
     try:
         session_data = session.getSessionData()

--- a/ikabot/function/developer.py
+++ b/ikabot/function/developer.py
@@ -2,9 +2,11 @@ from ikabot.helpers.dns import getAddress
 import ikabot
 import os
 import sys
+from ikabot.helpers.decorators import configurator
 
+
+@configurator
 def developer(session, event, stdin_fd, *args):
-    sys.stdin = os.fdopen(stdin_fd)
     print("\n=== Developer Information ===\n")
 
     # 1. Get the ikabot package directory
@@ -31,5 +33,4 @@ def developer(session, event, stdin_fd, *args):
     print("ikariam:", cookies.get("ikariam", "Not set"))
     print("gf-token-production:", cookies.get("gf-token-production", "Not set"))
     input("\nPress enter to return...")
-
-    event.set()
+    return None

--- a/ikabot/function/distributeResources.py
+++ b/ikabot/function/distributeResources.py
@@ -5,6 +5,7 @@ import traceback
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import banner
 from ikabot.helpers.pedirInfo import *
@@ -15,6 +16,22 @@ from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import addThousandSeparator
 
 
+@task("distributeResources")
+def do_it(session, routes, useFreighters, resource):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    routes : list
+    useFreighters : bool
+    resource : int
+    """
+    info = "\nDistribute {}\n".format(materials_names[resource])
+    setInfoSignal(session, info)
+    executeRoutes(session, routes, useFreighters)
+
+
+@configurator
 def distributeResources(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -24,8 +41,6 @@ def distributeResources(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
 
@@ -45,8 +60,7 @@ def distributeResources(session, event, stdin_fd, predetermined_input):
             print("({:d}) {}".format(i + 1, materials_names[i]))
         resource = read(min=0, max=5)
         if resource == 0:
-            event.set()  # give main process control before exiting
-            return
+            return None
         resource -= 1
 
         if resource == 0:
@@ -66,8 +80,7 @@ def distributeResources(session, event, stdin_fd, predetermined_input):
             routes = distribute_unevenly(session, resource, cities_ids, cities)
 
         if routes is None:
-            event.set()
-            return
+            return None
 
         banner()
         print("\nThe following shipments will be made:\n")
@@ -84,26 +97,17 @@ def distributeResources(session, event, stdin_fd, predetermined_input):
         print("\nProceed? [Y/n]")
         rta = read(values=["y", "Y", "n", "N", ""])
         if rta.lower() == "n":
-            event.set()
-            return
+            return None
 
     except KeyboardInterrupt:
-        event.set()
-        return
+        return None
 
-    set_child_mode(session)
-    event.set()  # this is where we give back control to main process
-
-    info = "\nDistribute {}\n".format(materials_names[resource])
-    setInfoSignal(session, info)
-
-    try:
-        executeRoutes(session, routes, useFreighters)  # plan trips for all the routes
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)  # sends message to telegram bot
-    finally:
-        session.logout()
+    return {
+        "session": session,
+        "routes": routes,
+        "useFreighters": useFreighters,
+        "resource": resource,
+    }
 
 
 def distribute_evenly(session, resource_type, cities_ids, cities):

--- a/ikabot/function/donate.py
+++ b/ikabot/function/donate.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -12,6 +13,7 @@ from ikabot.helpers.resources import *
 from ikabot.helpers.varios import *
 
 
+@configurator
 def donate(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -21,8 +23,6 @@ def donate(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
 

--- a/ikabot/function/donationBot.py
+++ b/ikabot/function/donationBot.py
@@ -9,7 +9,7 @@ from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.resources import getAvailableResources, getProductionPerHour
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import wait, getDateTime
@@ -89,149 +89,7 @@ def _get_donation_config(cities, donate_method, cityId):
     return donation_type, percentage
 
 
-def donationBot(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-        (cities_ids, cities) = getIdsOfCities(session)
-        cities_dict = {}
-        initials = [material_name[0] for material_name in materials_names]
-        print(
-            "Enter how often you want to donate in minutes. (min = 1, default = 1 day)"
-        )
-        waiting_time = read(min=1, digit=True, default=1 * 24 * 60)
-        print(
-            """Which donation method would you like to use to donate automatically? (default = 1)
-(1) Donate exceeding percentage of your storage capacity
-(2) Donate a percentage of production
-(3) Donate specific amount
-        """
-        )
-        donate_method = read(min=1, max=3, digit=True, default=1)
-
-        print(
-            """Do you wish to apply the same donation configuration to all cities? (default = 1)
-(1) Apply same configuration to all cities
-(2) Define configuration separately for each city
-        """
-        )
-        apply_to_all = read(min=1, max=2, digit=True, default=1) == 1
-
-        # Get donation configuration
-        if apply_to_all:
-            # Ask for configuration once
-            donation_type, percentage = _get_donation_config(cities, donate_method, cities_ids[0])
-            # Apply to all cities
-            for cityId in cities_ids:
-                cities_dict[cityId] = {
-                    "donation_type": donation_type,
-                    "percentage": percentage,
-                }
-        else:
-            # Ask for each city separately
-            for cityId in cities_ids:
-                tradegood = cities[cityId]["tradegood"]
-                initial = initials[int(tradegood)]
-                print(
-
-                    "In {} ({}), Do you wish to donate to the forest, to the trading good, to both or none? [f/t/b/n]".format(cities[cityId]["name"], initial)
-                )
-                f = "f"
-                t = "t"
-                b = "b"
-                n = "n"
-
-                rta = read(values=[f, f.upper(), t, t.upper(), b, b.upper(), n, n.upper()])
-                if rta.lower() == f:
-                    donation_type = "resource"
-                elif rta.lower() == t:
-                    donation_type = "tradegood"
-                elif rta.lower() == b:
-                    donation_type = "both"
-                else:
-                    donation_type = None
-                    percentage = None
-
-                if donation_type is not None and donate_method == 1:
-                    print(
-
-                        "What is the maximum percentage of your storage capacity that you wish to keep occupied? (the resources that exceed it, will be donated) (default: 80%)"
-
-                    )
-                    percentage = read(min=0, max=100, empty=True)
-                    if percentage == "":
-                        percentage = 80
-                    elif (
-                        percentage == 100
-                    ):  # if the user is ok with the storage beeing totally full, don't donate at all
-                        donation_type = None
-                elif donation_type is not None and donate_method == 2:
-                    print(
-
-                        "What is the percentage of your production that you wish to donate? (enter 0 to disable donation for the town) (default: 50%)"
-
-                    )
-                    percentage = read(
-                        min=0, max=100, empty=True
-                    )
-                    if percentage == "":
-                        percentage = 50
-                    elif percentage == 0:
-                        donation_type = None
-                elif donation_type is not None and donate_method == 3:
-                    print(
-
-                        "What is the amount would you like to donate? (enter 0 to disable donation for the town) (default: 10000)"
-
-                    )
-                    percentage = read(
-                        min=0, empty=True
-                    )  # no point changing the variable's name everywhere just for this
-                    if percentage == "":
-                        percentage = 10000
-                    elif percentage == 0:
-                        donation_type = None
-
-                cities_dict[cityId] = {
-                    "donation_type": donation_type,
-                    "percentage": percentage,
-                }
-
-        print("I will donate every {} minutes.".format(waiting_time))
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI donate every {} minutes\n".format(waiting_time)
-    setInfoSignal(session, info)
-    try:
-        do_it(
-            session,
-            cities_ids,
-            cities_dict,
-            waiting_time,
-            donate_method,
-        )
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
+@task("donationBot")
 def do_it(
     session,
     cities_ids,
@@ -239,6 +97,8 @@ def do_it(
     waiting_time,
     donate_method,
 ):
+    info = "\nI donate every {} minutes\n".format(waiting_time)
+    setInfoSignal(session, info)
     for cityId in cities_ids:
         try:
             html = session.get(city_url + cityId)
@@ -351,3 +211,122 @@ def do_it(
                 continue
 
         wait(waiting_time * 60)
+@configurator
+def donationBot(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+    (cities_ids, cities) = getIdsOfCities(session)
+    cities_dict = {}
+    initials = [material_name[0] for material_name in materials_names]
+    print(
+        "Enter how often you want to donate in minutes. (min = 1, default = 1 day)"
+    )
+    waiting_time = read(min=1, digit=True, default=1 * 24 * 60)
+    print(
+        """Which donation method would you like to use to donate automatically? (default = 1)
+(1) Donate exceeding percentage of your storage capacity
+(2) Donate a percentage of production
+(3) Donate specific amount
+    """
+    )
+    donate_method = read(min=1, max=3, digit=True, default=1)
+
+    print(
+        """Do you wish to apply the same donation configuration to all cities? (default = 1)
+(1) Apply same configuration to all cities
+(2) Define configuration separately for each city
+    """
+    )
+    apply_to_all = read(min=1, max=2, digit=True, default=1) == 1
+
+    # Get donation configuration
+    if apply_to_all:
+        # Ask for configuration once
+        donation_type, percentage = _get_donation_config(cities, donate_method, cities_ids[0])
+        # Apply to all cities
+        for cityId in cities_ids:
+            cities_dict[cityId] = {
+                "donation_type": donation_type,
+                "percentage": percentage,
+            }
+    else:
+        # Ask for each city separately
+        for cityId in cities_ids:
+            tradegood = cities[cityId]["tradegood"]
+            initial = initials[int(tradegood)]
+            print(
+
+                "In {} ({}), Do you wish to donate to the forest, to the trading good, to both or none? [f/t/b/n]".format(cities[cityId]["name"], initial)
+            )
+            f = "f"
+            t = "t"
+            b = "b"
+            n = "n"
+
+            rta = read(values=[f, f.upper(), t, t.upper(), b, b.upper(), n, n.upper()])
+            if rta.lower() == f:
+                donation_type = "resource"
+            elif rta.lower() == t:
+                donation_type = "tradegood"
+            elif rta.lower() == b:
+                donation_type = "both"
+            else:
+                donation_type = None
+                percentage = None
+
+            if donation_type is not None and donate_method == 1:
+                print(
+
+                    "What is the maximum percentage of your storage capacity that you wish to keep occupied? (the resources that exceed it, will be donated) (default: 80%)"
+
+                )
+                percentage = read(min=0, max=100, empty=True)
+                if percentage == "":
+                    percentage = 80
+                elif (
+                    percentage == 100
+                ):  # if the user is ok with the storage beeing totally full, don't donate at all
+                    donation_type = None
+            elif donation_type is not None and donate_method == 2:
+                print(
+
+                    "What is the percentage of your production that you wish to donate? (enter 0 to disable donation for the town) (default: 50%)"
+
+                )
+                percentage = read(
+                    min=0, max=100, empty=True
+                )
+                if percentage == "":
+                    percentage = 50
+                elif percentage == 0:
+                    donation_type = None
+            elif donation_type is not None and donate_method == 3:
+                print(
+
+                    "What is the amount would you like to donate? (enter 0 to disable donation for the town) (default: 10000)"
+
+                )
+                percentage = read(
+                    min=0, empty=True
+                )  # no point changing the variable's name everywhere just for this
+                if percentage == "":
+                    percentage = 10000
+                elif percentage == 0:
+                    donation_type = None
+
+            cities_dict[cityId] = {
+                "donation_type": donation_type,
+                "percentage": percentage,
+            }
+
+    print("I will donate every {} minutes.".format(waiting_time))
+    enter()
+    return {"session": session, "cities_ids": cities_ids, "cities_dict": cities_dict, "waiting_time": waiting_time, "donate_method": donate_method}
+

--- a/ikabot/function/dumpWorld.py
+++ b/ikabot/function/dumpWorld.py
@@ -21,16 +21,42 @@ from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import getDateTime, wait
 
-LINE_UP = "\033[1A"
-LINE_CLEAR = "\x1b[2K"
-#              status, history, start_time
-stop_updating = threading.Event()
-lock = threading.Lock()
-shared_data = ["", "", 0, stop_updating, lock]
-home = "USERPROFILE" if isWindows else "HOME"
-selected_islands = set()
+from ikabot.helpers.decorators import configurator, task
+
+@task("dumpWorld")
+def do_dumpWorld(session, waiting_time, coords, radius, shallow, non_empty_islands):
+    stop_updating = threading.Event()
+    lock = threading.Lock()
+    shared_data = ["", "", 0, stop_updating, lock]
+
+    thread = threading.Thread(target=update_terminal, args=(shared_data,), daemon=True)
+    thread.start()
+    
+    info = "\nDumped world data\n"
+    setInfoSignal(session, info)
+
+    start_time = time.time()
+    dump_path = do_it(
+        session, waiting_time, coords, radius, shallow, non_empty_islands, shared_data
+    )
+
+    shared_data[3].set()
+    shared_data[4].acquire()
+    time.sleep(5)
+
+    banner()
+    print(
+        "\n{}SUCCESS!{} World data has been dumped to {} in {}s \n".format(
+            bcolors.GREEN,
+            bcolors.ENDC,
+            dump_path,
+            str(round(time.time() - shared_data[2])),
+        )
+    )
+    enter()
 
 
+@configurator(blocking=True)
 def dumpWorld(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -40,98 +66,67 @@ def dumpWorld(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-
-    try:
-        banner()
-        if os.path.exists(os.getenv(home) + "/ikabot_world_dumps"):
-            print("1) Create new dump")
-            print("2) Load existing dump")
-            choice = read(min=1, max=2, digit=True)
-            if choice == 2:
-                view_dump(session, event)
-                event.set()
-                return
-        banner()
-        print(
-            "{}⚠️ BEWARE - THE RESULTING DUMP CONTAINS ACCOUNT IDENTIFYING INFORMATION ⚠️{}\n".format(
-                bcolors.WARNING, bcolors.ENDC
-            )
+    banner()
+    if os.path.exists(os.getenv(home) + "/ikabot_world_dumps"):
+        print("1) Create new dump")
+        print("2) Load existing dump")
+        choice = read(min=1, max=2, digit=True)
+        if choice == 2:
+            view_dump(session)
+            return None
+    banner()
+    print(
+        "{}⚠️ BEWARE - THE RESULTING DUMP CONTAINS ACCOUNT IDENTIFYING INFORMATION ⚠️{}\n".format(
+            bcolors.WARNING, bcolors.ENDC
         )
-        print(
-            "This action will take a couple of hours to complete. Are you sure you want to initiate a data dump now? (Y|N)"
-        )
+    )
+    print(
+        "This action will take a couple of hours to complete. Are you sure you want to initiate a data dump now? (Y|N)"
+    )
+    choice = read(values=["y", "Y", "n", "N"])
+    if choice in ["n", "N"]:
+        return None
+    print(
+        "Type in the waiting time between each request in miliseconds (default = 1500): "
+    )
+    choice = read(min=0, max=10000, digit=True, default=1500)
+    waiting_time = int(choice) / 1000
+    print(
+        "Do you want only shallow data about the islands? If yes you will not be able to search the dump by player names but the dump will be quick. (Y|N): "
+    )
+    choice = read(values=["y", "Y", "n", "N"])
+    shallow = choice in ["y", "Y"]
+    coords = None
+    radius = None
+    non_empty_islands = False
+    if not shallow:
+        print("Do you want to only dump a part of the map? (Y|N)")
         choice = read(values=["y", "Y", "n", "N"])
-        if choice in ["n", "N"]:
-            event.set()
-            return
-        print(
-            "Type in the waiting time between each request in miliseconds (default = 1500): "
-        )
-        choice = read(min=0, max=10000, digit=True, default=1500)
-        waiting_time = int(choice) / 1000
-        print(
-            "Do you want only shallow data about the islands? If yes you will not be able to search the dump by player names but the dump will be quick. (Y|N): "
-        )
-        choice = read(values=["y", "Y", "n", "N"])
-        shallow = choice in ["y", "Y"]
-        coords = None
-        radius = None
-        non_empty_islands = False
-        if not shallow:
-            print("Do you want to only dump a part of the map? (Y|N)")
+        if choice in ["y", "Y"]:
+            print('Type in a center point (x,y): (type "skip" to skip this step)')
+            input = read()
+            if input.strip().lower() != "skip":
+                coords = input.replace("(", "").replace(")", "").split(",")
+                coords = (int(coords[0]), int(coords[1]))
+                print(
+                    "Type in a max distance from the center point: (default = 15)"
+                )
+                radius = read(min=0, max=200, digit=True, default=15)
+            print("Do you want to only dump islands with at least 1 town? (Y|N)")
             choice = read(values=["y", "Y", "n", "N"])
-            if choice in ["y", "Y"]:
-                print('Type in a center point (x,y): (type "skip" to skip this step)')
-                input = read()
-                if input.strip().lower() != "skip":
-                    coords = input.replace("(", "").replace(")", "").split(",")
-                    coords = (int(coords[0]), int(coords[1]))
-                    print(
-                        "Type in a max distance from the center point: (default = 15)"
-                    )
-                    radius = read(min=0, max=200, digit=True, default=15)
-                print("Do you want to only dump islands with at least 1 town? (Y|N)")
-                choice = read(values=["y", "Y", "n", "N"])
-                non_empty_islands = choice in ["y", "Y"]
+            non_empty_islands = choice in ["y", "Y"]
 
-        thread = threading.Thread(target=update_terminal, args=(shared_data,), daemon=True)
-        thread.start()
-        set_child_mode(session)
-        info = "\nDumped world data\n"
-        setInfoSignal(session, info)
-
-        dump_path = do_it(
-            session, waiting_time, coords, radius, shallow, non_empty_islands
-        )
-
-        shared_data[3].set()
-        shared_data[4].acquire()
-        time.sleep(5)
-
-        banner()
-        print(
-            "\n{}SUCCESS!{} World data has been dumped to {} in {}s \n".format(
-                bcolors.GREEN,
-                bcolors.ENDC,
-                dump_path,
-                str(round(time.time() - shared_data[2])),
-            )
-        )
-        enter()
-        event.set()
-        return
-    except Exception:
-        shared_data[3].set()
-        shared_data[4].acquire(timeout=10)
-        event.set()
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-        return
+    return {
+        "session": session,
+        "waiting_time": waiting_time,
+        "coords": coords,
+        "radius": radius,
+        "shallow": shallow,
+        "non_empty_islands": non_empty_islands
+    }
 
 
-def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
+def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands, shared_data):
     """
     Parameters
     ----------
@@ -143,6 +138,8 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
         Id of the island to start the dump from (0 starts from beginning)
     shallow : str
         String that determines if the data should be shallow (only map accessible data)
+    shared_data : list
+        State sharing list for terminal updates
 
     Returns
     -------
@@ -165,8 +162,8 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
     shared_data.append(world)
     # scan 0 to 50 x and y
     shallow_islands = []
-    update_status("Initiating first map sweep", 0, 0, True)
-    update_status("Getting (0-50,0-50) islands", 25, 1.25)
+    update_status("Initiating first map sweep", 0, 0, shared_data, True)
+    update_status("Getting (0-50,0-50) islands", 25, 1.25, shared_data)
     data = session.post(
         "action=WorldMap&function=getJSONArea&x_min=0&x_max=50&y_min=0&y_max=50"
     )
@@ -184,7 +181,7 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
                     "players": val2[7],
                 }
             )
-    update_status("Getting (50-100,0-50) islands", 50, 2.5)
+    update_status("Getting (50-100,0-50) islands", 50, 2.5, shared_data)
     time.sleep(0.5)
     data = session.post(
         "action=WorldMap&function=getJSONArea&x_min=50&x_max=100&y_min=0&y_max=50"
@@ -203,7 +200,7 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
                     "players": val2[7],
                 }
             )
-    update_status("Getting (0-50,50-100) islands", 75, 3.75)
+    update_status("Getting (0-50,50-100) islands", 75, 3.75, shared_data)
     time.sleep(0.5)
     data = session.post(
         "action=WorldMap&function=getJSONArea&x_min=0&x_max=50&y_min=50&y_max=100"
@@ -222,7 +219,7 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
                     "players": val2[7],
                 }
             )
-    update_status("Getting (50-100,50-100) islands", 100, 5)
+    update_status("Getting (50-100,50-100) islands", 100, 5, shared_data)
     time.sleep(0.5)
     data = session.post(
         "action=WorldMap&function=getJSONArea&x_min=50&x_max=100&y_min=50&y_max=100"
@@ -270,7 +267,7 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
 
     if shallow:
         dump_name = dump_name.replace(".json.gz", "_shallow") + ".json.gz"
-        update_status("Shallow dump is on. Dumping data...", 100, 100, True)
+        update_status("Shallow dump is on. Dumping data...", 100, 100, shared_data, True)
         world["islands"] = shallow_islands
         dump(world, dump_path, dump_name)
         return dump_path + dump_name
@@ -298,19 +295,20 @@ def do_it(session, waiting_time, coords, radius, shallow, non_empty_islands):
         ),
         100,
         5,
+        shared_data,
         True,
     )
-    update_status("Getting data for each island. This will take a while...", 0, 5, True)
+    update_status("Getting data for each island. This will take a while...", 0, 5, shared_data, True)
 
     # scan each island
 
     all_island = sorted(all_island)
     dump_islands(shared_data, all_island, waiting_time, session)
-    update_status("Got {} individual islands".format(len(all_island)), 100, 100, True)
+    update_status("Got {} individual islands".format(len(all_island)), 100, 100, shared_data, True)
 
     name_suffix = "_partial" if partial else ""
     dump_name = dump_name.replace(".json.gz", name_suffix) + ".json.gz"
-    update_status("Dumping data to {}".format(dump_path + dump_name), 100, 100, True)
+    update_status("Dumping data to {}".format(dump_path + dump_name), 100, 100, shared_data, True)
     dump(shared_data[5], dump_path, dump_name)
     return dump_path + dump_name
 
@@ -335,6 +333,7 @@ def dump_islands(shared_data, all_island, waiting_time, session):
             ),
             len(shared_data[5]["islands"]) / world_islands_number * 100,
             5 + (len(shared_data[5]["islands"]) / world_islands_number * 95),
+            shared_data
         )
         html = ""
         try:
@@ -342,9 +341,9 @@ def dump_islands(shared_data, all_island, waiting_time, session):
         except Exception:
             # try again
             html = session.get("view=island&islandId=" + str(island_id))
-        island = getIsland(html)
+        island_data = getIsland(html)
         shared_data[4].acquire()
-        shared_data[5]["islands"].append(island)
+        shared_data[5]["islands"].append(island_data)
         shared_data[4].release()
         time.sleep(waiting_time)
 
@@ -370,11 +369,11 @@ def update_terminal(shared_data):
             )
             shared_data[4].release()
             time.sleep(0.05)
-        if stop_updating.is_set():
+        if shared_data[3].is_set():
             return
 
 
-def update_status(message, percent, percent_total, add_history=False):
+def update_status(message, percent, percent_total, shared_data, add_history=False):
     shared_data[4].acquire()
     shared_data[0] = (
         message
@@ -389,8 +388,8 @@ def update_status(message, percent, percent_total, add_history=False):
     shared_data[4].release()
 
 
-def view_dump(session, event):
-
+def view_dump(session):
+    selected_islands = set()
 
     files = [
         file.replace("\\", "/")
@@ -416,7 +415,7 @@ def view_dump(session, event):
 
     while True:
         banner()
-        print_map(selected_dump["islands"])
+        print_map(selected_dump["islands"], selected_islands)
         print("0) Back")
         print("1) Search islands by island criteria")
         if not selected_dump["shallow"]:
@@ -427,7 +426,6 @@ def view_dump(session, event):
 
         choice = read(min=0, max=5, digit=True)
         if choice == 0:
-            event.set()
             return
         elif choice == 1:
             print(
@@ -668,12 +666,14 @@ def view_dump(session, event):
 
 
 
-def print_map(islands):
+def print_map(islands, selected_islands):
     """Prints out a 100x100 matrix with all world islands on it. Selected islands are colored red.
     Parameters
     ----------
     islands : [object]
         List of island objects to be displayed
+    selected_islands: set
+        Set of selected island IDs
     """
 
     map = [

--- a/ikabot/function/getStatus.py
+++ b/ikabot/function/getStatus.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 """Account status overview.
@@ -516,6 +517,7 @@ def collectData(session):
     }
 
 
+@configurator
 def getStatus(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -530,8 +532,6 @@ def getStatus(session, event, stdin_fd, predetermined_input):
     entirely from that in-memory data without any further requests. Selecting
     (3) re-scans the account on demand and refreshes the cache.
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         color_arr = [

--- a/ikabot/function/importExportCookie.py
+++ b/ikabot/function/importExportCookie.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -61,6 +62,7 @@ def wait_for_key_or_timeout(key, timeout_seconds):
             termios.tcsetattr(sys.stdin, termios.TCSADRAIN, old_settings)
 
 
+@configurator
 def importExportCookie(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -70,8 +72,6 @@ def importExportCookie(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     banner()
     try:
         print("Do you want to import or export the cookie?")

--- a/ikabot/function/killTasks.py
+++ b/ikabot/function/killTasks.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import datetime
@@ -9,6 +10,7 @@ from ikabot.helpers.pedirInfo import enter, read
 from ikabot.helpers.process import run, updateProcessList
 
 
+@configurator
 def killTasks(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -18,8 +20,6 @@ def killTasks(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         while True:
             banner()

--- a/ikabot/function/loadCustomModule.py
+++ b/ikabot/function/loadCustomModule.py
@@ -8,26 +8,10 @@ from ikabot.helpers.gui import *
 from ikabot.config import *
 from importlib.machinery import SourceFileLoader
 
-def loadCustomModule(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    # Fix for Linux: Reopen stdin to ensure terminal interaction works in threads
-    if sys.platform != "win32":
-        try:
-            sys.stdin = open('/dev/tty', 'r')
-        except Exception:
-            sys.stdin = os.fdopen(stdin_fd)
-    else:
-        sys.stdin = os.fdopen(stdin_fd)
+from ikabot.helpers.decorators import configurator
 
-    config.predetermined_input = predetermined_input
-    
+@configurator
+def loadCustomModule(session, event, stdin_fd, predetermined_input):
     while True:
         try:
             banner()
@@ -48,8 +32,7 @@ def loadCustomModule(session, event, stdin_fd, predetermined_input):
             choice = read(min=0, max=len(modules) + 2, digit=True)
 
             if choice == 0:
-                event.set()
-                return
+                return None
 
             elif choice == 1:
                 banner()
@@ -162,12 +145,11 @@ def loadCustomModule(session, event, stdin_fd, predetermined_input):
                 # Execute the function (must match filename)
                 getattr(module, name)(session, event, stdin_fd, predetermined_input)
 
-                event.set()
-                return
+                return None
 
         except Exception:
             print('\n>> Error in Custom Module Manager:')
             traceback.print_exc()
             enter()
-            event.set()
             break
+    return None

--- a/ikabot/function/loginDaily.py
+++ b/ikabot/function/loginDaily.py
@@ -5,369 +5,15 @@
 import sys
 import time
 import traceback
+import re
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
 from ikabot.helpers.gui import bcolors, enter
 from ikabot.helpers.pedirInfo import chooseCity, getIdsOfCities
-from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import getDateTime, timeStringToSec, wait
-
-
-earliest_wakeup_time = 24 * 60 * 60
-wine_city = wood_city = luxury_city = favour_tasks = collect_ambrosia = None
-
-
-def loginDaily(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
-        global wine_city
-        print("Choose the city where the daily login bonus wine will be sent:")
-        wine_city = chooseCity(session)
-        print("Do you want to automatically activate the cinetheatre bonus? (Y|N)")
-        choice = read(values=["y", "Y", "n", "N"])
-        if choice in ["y", "Y"]:
-
-            # choose city for wood
-            print("Choose the city where the wood bonus will be activated:")
-            wood_city = chooseCity(session)
-
-            # choose city for luxury resource
-            print("Choose the city where the luxury resource bonus will be activated:")
-            luxury_city = chooseCity(session)
-        print("Do you want to automatically collect the 'Divine Imagination' ambrosia bonus? (Y|N)")
-        choice = read(values=["y", "Y", "n", "N"])
-        if choice in ["y", "Y"]:
-            global collect_ambrosia
-            collect_ambrosia = True
-        print("Do you want to collect the favour automatically? (Y|N)")
-        choice = read(values=["y", "Y", "n", "N"])
-        if choice in ["y", "Y"]:
-            favour_tasks = [t for t in tasks]
-
-            def modify_tasks():
-                banner()
-                print(
-                    "Choose which daily tasks will be done/collected by Ikabot automatically."
-                )
-                print(
-                    f"Tasks in {bcolors.BLUE}blue{bcolors.ENDC} WILL be done automatically, tasks in {bcolors.STONE}grey{bcolors.ENDC} WILL NOT be done."
-                )
-                print("Press [ENTER] or type in [Y] to confirm selection")
-                for i, task in enumerate(tasks):
-                    if task in favour_tasks:
-                        print(i + 1, ") ", bcolors.BLUE, task, bcolors.ENDC)
-                    else:
-                        print(i + 1, ") ", bcolors.STONE, task, bcolors.ENDC)
-                choice = read(
-                    min=1,
-                    max=len(tasks),
-                    empty=True,
-                    digit=True,
-                    additionalValues=["y", "Y"],
-                )
-                if not choice or (not choice.isdigit() and choice.lower() == "y"):
-                    return
-                choice -= 1
-                if list(tasks)[choice] in favour_tasks:
-                    favour_tasks.remove(list(tasks)[choice])
-                else:
-                    favour_tasks.append(list(tasks)[choice])
-                return modify_tasks()
-
-            modify_tasks()
-
-        print("I will do the thing.")
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI enter every day\n"
-    setInfoSignal(session, info)
-    try:
-        do_it(
-            session,
-            wine_city=wine_city,
-            wood_city=wood_city,
-            luxury_city=luxury_city,
-            favour_tasks=favour_tasks,
-            collect_ambrosia=collect_ambrosia,
-        )
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
-def do_it(session, wine_city, wood_city, luxury_city, favour_tasks, collect_ambrosia):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    """
-    message_sent = False
-    while True:
-        (ids, cities) = getIdsOfCities(session)
-        global earliest_wakeup_time
-        earliest_wakeup_time = 24 * 60 * 60
-        # collect daily bonus wine
-        html = session.post(city_url + str(wine_city["id"]))
-        url = "action=AvatarAction&function=giveDailyActivityBonus&dailyActivityBonusCitySelect={0}&startPageShown=1&detectedDevice=1&autoLogin=on&cityId={0}&activeTab=multiTab2&backgroundView=city&currentCityId={0}&actionRequest={1}&ajax=1".format(
-            wine_city["id"], actionRequest
-        )
-        session.post(url)
-
-        def get_remaining_time_cinetheatre(features):
-            ewt = 999999999
-            for i, feature in enumerate(["Resource", "Tradegood", "Favour"]):
-                if features[i] and f"js_nextPossible{feature}" in features[i]:
-                    remaining_time_str = re.search(
-                        rf'js_nextPossible{feature}\\">([\S\s]*?)<', features[i]
-                    )
-                    assert (
-                        remaining_time_str
-                    ), f"Could not get remaining time for {feature} cultural feature"
-                    remaining_time_str = remaining_time_str.group(1).strip()
-                    sec_to_wait = (
-                        timeStringToSec(remaining_time_str) + 60
-                    )  # add 60s because of rounding errors
-                    ewt = sec_to_wait if sec_to_wait < ewt else ewt
-            return ewt
-
-        # collect wood cultural bonus
-        if wood_city:
-            html = session.post(city_url + str(wood_city["id"]))
-            html = session.post(
-                f"view=cinema&visit=1&currentCityId={wood_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
-            )
-            features = (
-                html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
-            )
-            features = [f for f in features if "form" in f or "js_nextPossible" in f]
-            if "js_nextPossibleResource" in features[0]:
-                earliest_wakeup_time = (
-                    get_remaining_time_cinetheatre(features)
-                    if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
-                    else earliest_wakeup_time
-                )
-            else:
-                videoId = re.search(
-                    r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[0]
-                )
-                assert videoId, "Could not find a match for videoId in html"
-                videoId = videoId.group(1)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=51&videoId={str(videoId)}&backgroundView=city&currentCityId={wood_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-                session.setStatus("Waiting 55s to watch video for wood bonus")
-                wait(55)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={wood_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-
-        wait(1)
-
-        # collect luxury good cultural bonus
-        if luxury_city:
-            html = session.post(city_url + str(luxury_city["id"]))
-            html = session.post(
-                f"view=cinema&visit=1&currentCityId={luxury_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
-            )
-            features = (
-                html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
-            )
-            features = [f for f in features if "form" in f or "js_nextPossible" in f]
-            if "js_nextPossibleTradegood" in features[1]:
-                earliest_wakeup_time = (
-                    get_remaining_time_cinetheatre(features)
-                    if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
-                    else earliest_wakeup_time
-                )
-            else:
-                videoId = re.search(
-                    r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[1]
-                )
-                assert videoId, "Could not find a match for videoId in html"
-                videoId = videoId.group(1)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=52&videoId={str(videoId)}&backgroundView=city&currentCityId={luxury_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-                session.setStatus("Waiting 55s to watch video for luxury good bonus")
-                wait(55)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={luxury_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-
-        wait(1)
-
-        # collect favour cultural bonus
-        if wood_city:
-            favour_cinetheater_city = wood_city
-        if luxury_city:
-            favour_cinetheater_city = luxury_city
-        if favour_cinetheater_city:
-            html = session.post(city_url + str(favour_cinetheater_city["id"]))
-            html = session.post(
-                f"view=cinema&visit=1&currentCityId={favour_cinetheater_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
-            )
-            features = (
-                html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
-            )
-            features = [f for f in features if "form" in f or "js_nextPossible" in f]
-            if "js_nextPossibleFavour" in features[2]:
-                earliest_wakeup_time = (
-                    get_remaining_time_cinetheatre(features)
-                    if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
-                    else earliest_wakeup_time
-                )
-            else:
-                videoId = re.search(
-                    r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[2]
-                )
-                assert videoId, "Could not find a match for videoId in html"
-                videoId = videoId.group(1)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=53&videoId={str(videoId)}&backgroundView=city&currentCityId={favour_cinetheater_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-                session.setStatus(
-                    "Waiting 55s to watch video for favour cultural bonus"
-                )
-                wait(55)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={favour_cinetheater_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-
-        # collect Imaginación divina ambrosia video bonus
-        if collect_ambrosia:
-            html = session.post(city_url + str(wine_city["id"]))
-            html = session.post(
-                f"view=cinema&visit=1&currentCityId={wine_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
-            )
-            features = (
-                html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
-            )
-            features = [f for f in features if "form" in f or "js_nextPossible" in f]
-            if len(features) > 3 and "js_nextPossibleAmbrosia" in features[3]:
-                remaining_time_str = re.search(
-                    r'js_nextPossibleAmbrosia\\">([\S\s]*?)<', features[3]
-                )
-                if remaining_time_str:
-                    remaining_time_str = remaining_time_str.group(1).strip()
-                    sec_to_wait = timeStringToSec(remaining_time_str) + 60
-                    earliest_wakeup_time = (
-                        sec_to_wait if sec_to_wait < earliest_wakeup_time else earliest_wakeup_time
-                    )
-            elif len(features) > 3 and "form" in features[3]:
-                videoId = re.search(
-                    r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[3]
-                )
-                assert videoId, "Could not find a match for videoId in ambrosia html"
-                videoId = videoId.group(1)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=54&videoId={str(videoId)}&backgroundView=city&currentCityId={wine_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-                session.setStatus("Waiting 55s to watch video for ambrosia bonus")
-                wait(55)
-                session.post(
-                    f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={wine_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
-                )
-
-        # get waiting times for all three cinetheatre features.
-
-        wait(1)
-
-        if wood_city or luxury_city or favour_cinetheater_city:
-            html = session.post(city_url + str(wine_city["id"]))
-            html = session.post(
-                f"view=cinema&visit=1&currentCityId={wine_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
-            )
-            features = (
-                html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
-            )
-            features = [f for f in features if "form" in f or "js_nextPossible" in f]
-            earliest_wakeup_time = (
-                get_remaining_time_cinetheatre(features)
-                if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
-                else earliest_wakeup_time
-            )
-
-        wait(1)
-
-        # do favour tasks in wine city
-        for task in favour_tasks:
-            html = session.post(city_url + str(wine_city["id"]))
-            html = session.post(
-                f"view=dailyTasks&backgroundView=city&currentCityId={wine_city['id']}&actionRequest={actionRequest}&ajax=1"
-            )
-            # check if favour is full (2500)
-            match = re.search(r"currentFavor([\S\s]*?)(\d+)\s*<", html)
-            assert match, "Can not obtain current favour amount"
-            if match.group(2) == "2500":
-                # send notification we are full on favour
-                if not message_sent:
-                    sendToBot(session, "Favour was not collected as you are full on it")
-                    message_sent = (
-                        True  # we don't want to spam the message, only once is enough
-                    )
-                break
-            matches = re.findall(r"<tr([\S\s]*?)tr>", html)
-            rows = [
-                matches[1],
-                matches[2],
-                matches[4],
-                matches[5],
-                matches[7],
-                matches[8],
-                matches[10],
-                matches[11],
-            ]
-            tasks[task](session, rows)
-            match = re.search(
-                r'"dailyTasksCountdown":{"countdown":{"enddate":(\d+),"currentdate":(\d+),"timeout_ajax',
-                html,
-            )
-            assert match, "Can not get remaning daily tasks time"
-            sec_remaining = (int(match.group(1)) - int(match.group(2))) - 600
-            earliest_wakeup_time = (
-                sec_remaining
-                if sec_remaining < earliest_wakeup_time
-                else earliest_wakeup_time
-            )
-
-        # find capital and get ambro bonus from fountain if it's active
-        for id in ids:
-            html = session.post(city_url + str(id))
-            if 'class="fountain' in html:  # is capital
-                if 'class="fountain_active' in html:  # foutain is active
-                    url = "action=AmbrosiaFountainActions&function=collect&backgroundView=city&currentCityId={0}&templateView=ambrosiaFountain&actionRequest={1}&ajax=1".format(
-                        id, actionRequest
-                    )
-                    session.post(url)
-                break
-            wait(1)
-        earliest_wakeup_time = abs(
-            earliest_wakeup_time
-        )  # funnily enough, it's possible to have the earliest wakeup time be a negative number, this happens if there is less than 10 minutes remaning until tasks reset
-        session.setStatus(
-            f"Last activity @{getDateTime()}, next activity @{getDateTime(time.time()+earliest_wakeup_time)}"
-        )
-        wait(earliest_wakeup_time, 20)
+from ikabot.helpers.decorators import configurator, task
 
 
 def is_collectable(row):
@@ -386,9 +32,8 @@ def is_collectable(row):
     return "textLineThrough" not in row and progress_left == progress_right
 
 
-def collect_resource_favour(session, table):
+def collect_resource_favour(session, table, wine_city, earliest_wakeup_time):
     # literally just collect the first two tasks if they're done
-    global wine_city
     passive1 = table[0]
     passive2 = table[1]
 
@@ -405,11 +50,12 @@ def collect_resource_favour(session, table):
             f"action=CollectDailyTasksFavor&taskId={taskId}&ajax=1&backgroundView=city&currentCityId={wine_city['id']}&templateView=dailyTasks&actionRequest={actionRequest}&ajax=1"
         )
         wait(1)
+    
+    return earliest_wakeup_time
 
 
-def look(session, table):
+def look(session, table, wine_city, earliest_wakeup_time):
     # collect if collectable, otherwise look at specified view then collect
-    global earliest_wakeup_time, wine_city
     for r in table:
         if "task_amount_28" in r:  # visit shop
             if is_collectable(r):
@@ -458,21 +104,22 @@ def look(session, table):
                     f"action=CollectDailyTasksFavor&taskId=26&ajax=1&backgroundView=city&currentCityId={wine_city['id']}&templateView=dailyTasks&actionRequest={actionRequest}&ajax=1"
                 )
                 wait(1)
+    
+    return earliest_wakeup_time
 
 
-def capture_runs(session, table):
+def capture_runs(session, table, wine_city, earliest_wakeup_time):
     # divide number of point by 115, take top integer, invoke autopirate for that many runs, collect bonus
-    pass
+    return earliest_wakeup_time
 
 
-def donate_wood(session, table):
+def donate_wood(session, table, wine_city, earliest_wakeup_time):
     # find city with most wood and donate number of it to lux resource or wood production (randomly chosen), collect bonus
-    pass
+    return earliest_wakeup_time
 
 
-def stay_online_30_mins(session, table):
+def stay_online_30_mins(session, table, wine_city, earliest_wakeup_time):
     # collect if possible, otherwise earliest wake time is 31 mins from now, then it will be collected in the next pass
-    global earliest_wakeup_time, wine_city
     for r in table:
         if "task_amount_23" in r:  # stay online for 30 mins
             if is_collectable(r):
@@ -484,11 +131,11 @@ def stay_online_30_mins(session, table):
                 earliest_wakeup_time = (
                     31 * 60 if 31 * 60 < earliest_wakeup_time else earliest_wakeup_time
                 )
+    return earliest_wakeup_time
 
 
-def complete_tasks(session, table):
+def complete_tasks(session, table, wine_city, earliest_wakeup_time):
     # collect any still collectable tasks, this one should always run last
-    global wine_city
     for row in table:
         if is_collectable(row):
             taskId = re.search(r'taskId=([\S\s]*?)\\"', row).group(1)
@@ -496,13 +143,368 @@ def complete_tasks(session, table):
                 f"action=CollectDailyTasksFavor&taskId={taskId}&ajax=1&backgroundView=city&currentCityId={wine_city['id']}&templateView=dailyTasks&actionRequest={actionRequest}&ajax=1"
             )
             wait(1)
+    return earliest_wakeup_time
 
 
-tasks = {
+TASK_FUNCTIONS = {
     "Collect resource favour": collect_resource_favour,
     "Look at hightscore/shop/inventory": look,
     "Stay online for 30 mins": stay_online_30_mins,
-    #'Conduct capture runs': capture_runs,
-    #'Donate wood': donate_wood,
-    "Complete 2/all tasks": complete_tasks,  # must be last
+    "Complete 2/all tasks": complete_tasks,
 }
+
+
+@task("loginDaily")
+def do_it(session, wine_city, wood_city, luxury_city, favour_tasks, collect_ambrosia):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    wine_city : dict
+    wood_city : dict
+    luxury_city : dict
+    favour_tasks : list
+    collect_ambrosia : bool
+    """
+    info = "\nI enter every day\n"
+    setInfoSignal(session, info)
+    message_sent = False
+    
+    while True:
+        try:
+            (ids, cities) = getIdsOfCities(session)
+            earliest_wakeup_time = 24 * 60 * 60
+            # collect daily bonus wine
+            html = session.post(city_url + str(wine_city["id"]))
+            url = "action=AvatarAction&function=giveDailyActivityBonus&dailyActivityBonusCitySelect={0}&startPageShown=1&detectedDevice=1&autoLogin=on&cityId={0}&activeTab=multiTab2&backgroundView=city&currentCityId={0}&actionRequest={1}&ajax=1".format(
+                wine_city["id"], actionRequest
+            )
+            session.post(url)
+
+            def get_remaining_time_cinetheatre(features):
+                ewt = 999999999
+                for i, feature in enumerate(["Resource", "Tradegood", "Favour"]):
+                    if features[i] and f"js_nextPossible{feature}" in features[i]:
+                        remaining_time_str = re.search(
+                            rf'js_nextPossible{feature}\\">([\S\s]*?)<', features[i]
+                        )
+                        assert (
+                            remaining_time_str
+                        ), f"Could not get remaining time for {feature} cultural feature"
+                        remaining_time_str = remaining_time_str.group(1).strip()
+                        sec_to_wait = (
+                            timeStringToSec(remaining_time_str) + 60
+                        )  # add 60s because of rounding errors
+                        ewt = sec_to_wait if sec_to_wait < ewt else ewt
+                return ewt
+
+            # collect wood cultural bonus
+            if wood_city:
+                html = session.post(city_url + str(wood_city["id"]))
+                html = session.post(
+                    f"view=cinema&visit=1&currentCityId={wood_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
+                )
+                features = (
+                    html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
+                )
+                features = [f for f in features if "form" in f or "js_nextPossible" in f]
+                if "js_nextPossibleResource" in features[0]:
+                    earliest_wakeup_time = (
+                        get_remaining_time_cinetheatre(features)
+                        if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
+                        else earliest_wakeup_time
+                    )
+                else:
+                    videoId = re.search(
+                        r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[0]
+                    )
+                    assert videoId, "Could not find a match for videoId in html"
+                    videoId = videoId.group(1)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=51&videoId={str(videoId)}&backgroundView=city&currentCityId={wood_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+                    session.setStatus("Waiting 55s to watch video for wood bonus")
+                    wait(55)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={wood_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+
+            wait(1)
+
+            # collect luxury good cultural bonus
+            if luxury_city:
+                html = session.post(city_url + str(luxury_city["id"]))
+                html = session.post(
+                    f"view=cinema&visit=1&currentCityId={luxury_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
+                )
+                features = (
+                    html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
+                )
+                features = [f for f in features if "form" in f or "js_nextPossible" in f]
+                if "js_nextPossibleTradegood" in features[1]:
+                    earliest_wakeup_time = (
+                        get_remaining_time_cinetheatre(features)
+                        if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
+                        else earliest_wakeup_time
+                    )
+                else:
+                    videoId = re.search(
+                        r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[1]
+                    )
+                    assert videoId, "Could not find a match for videoId in html"
+                    videoId = videoId.group(1)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=52&videoId={str(videoId)}&backgroundView=city&currentCityId={luxury_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+                    session.setStatus("Waiting 55s to watch video for luxury good bonus")
+                    wait(55)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={luxury_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+
+            wait(1)
+
+            # collect favour cultural bonus
+            favour_cinetheater_city = None
+            if wood_city:
+                favour_cinetheater_city = wood_city
+            if luxury_city:
+                favour_cinetheater_city = luxury_city
+            if favour_cinetheater_city:
+                html = session.post(city_url + str(favour_cinetheater_city["id"]))
+                html = session.post(
+                    f"view=cinema&visit=1&currentCityId={favour_cinetheater_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
+                )
+                features = (
+                    html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
+                )
+                features = [f for f in features if "form" in f or "js_nextPossible" in f]
+                if "js_nextPossibleFavour" in features[2]:
+                    earliest_wakeup_time = (
+                        get_remaining_time_cinetheatre(features)
+                        if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
+                        else earliest_wakeup_time
+                    )
+                else:
+                    videoId = re.search(
+                        r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[2]
+                    )
+                    assert videoId, "Could not find a match for videoId in html"
+                    videoId = videoId.group(1)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=53&videoId={str(videoId)}&backgroundView=city&currentCityId={favour_cinetheater_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+                    session.setStatus(
+                        "Waiting 55s to watch video for favour cultural bonus"
+                    )
+                    wait(55)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={favour_cinetheater_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+
+            # collect Imaginación divina ambrosia video bonus
+            if collect_ambrosia:
+                html = session.post(city_url + str(wine_city["id"]))
+                html = session.post(
+                    f"view=cinema&visit=1&currentCityId={wine_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
+                )
+                features = (
+                    html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
+                )
+                features = [f for f in features if "form" in f or "js_nextPossible" in f]
+                if len(features) > 3 and "js_nextPossibleAmbrosia" in features[3]:
+                    remaining_time_str = re.search(
+                        r'js_nextPossibleAmbrosia\\">([\S\s]*?)<', features[3]
+                    )
+                    if remaining_time_str:
+                        remaining_time_str = remaining_time_str.group(1).strip()
+                        sec_to_wait = timeStringToSec(remaining_time_str) + 60
+                        earliest_wakeup_time = (
+                            sec_to_wait if sec_to_wait < earliest_wakeup_time else earliest_wakeup_time
+                        )
+                elif len(features) > 3 and "form" in features[3]:
+                    videoId = re.search(
+                        r'name=\\"videoId\\"\s*value=\\"(\d+)\\"', features[3]
+                    )
+                    assert videoId, "Could not find a match for videoId in ambrosia html"
+                    videoId = videoId.group(1)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=requestBonus&bonusId=54&videoId={str(videoId)}&backgroundView=city&currentCityId={wine_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+                    session.setStatus("Waiting 55s to watch video for ambrosia bonus")
+                    wait(55)
+                    session.post(
+                        f"view=noViewChange&action=AdVideoRewardAction&function=watchVideo&videoId={str(videoId)}&backgroundView=city&currentCityId={wine_city['id']}&templateView=cinema&actionRequest={actionRequest}&ajax=1"
+                    )
+
+            # get waiting times for all three cinetheatre features.
+
+            wait(1)
+
+            if wood_city or luxury_city or favour_cinetheater_city:
+                html = session.post(city_url + str(wine_city["id"]))
+                html = session.post(
+                    f"view=cinema&visit=1&currentCityId={wine_city['id']}&backgroundView=city&actionRequest={actionRequest}&ajax=1"
+                )
+                features = (
+                    html.split('id=\\"VideoRewards\\"')[1].split("ul>")[0].split("li>")
+                )
+                features = [f for f in features if "form" in f or "js_nextPossible" in f]
+                earliest_wakeup_time = (
+                    get_remaining_time_cinetheatre(features)
+                    if get_remaining_time_cinetheatre(features) < earliest_wakeup_time
+                    else earliest_wakeup_time
+                )
+
+            wait(1)
+
+            # do favour tasks in wine city
+            for task_name in favour_tasks:
+                if task_name not in TASK_FUNCTIONS:
+                    continue
+                html = session.post(city_url + str(wine_city["id"]))
+                html = session.post(
+                    f"view=dailyTasks&backgroundView=city&currentCityId={wine_city['id']}&actionRequest={actionRequest}&ajax=1"
+                )
+                # check if favour is full (2500)
+                match = re.search(r"currentFavor([\S\s]*?)(\d+)\s*<", html)
+                assert match, "Can not obtain current favour amount"
+                if match.group(2) == "2500":
+                    # send notification we are full on favour
+                    if not message_sent:
+                        sendToBot(session, "Favour was not collected as you are full on it")
+                        message_sent = (
+                            True  # we don't want to spam the message, only once is enough
+                        )
+                    break
+                matches = re.findall(r"<tr([\S\s]*?)tr>", html)
+                rows = [
+                    matches[1],
+                    matches[2],
+                    matches[4],
+                    matches[5],
+                    matches[7],
+                    matches[8],
+                    matches[10],
+                    matches[11],
+                ]
+                earliest_wakeup_time = TASK_FUNCTIONS[task_name](session, rows, wine_city, earliest_wakeup_time)
+                match = re.search(
+                    r'"dailyTasksCountdown":{"countdown":{"enddate":(\d+),"currentdate":(\d+),"timeout_ajax',
+                    html,
+                )
+                assert match, "Can not get remaning daily tasks time"
+                sec_remaining = (int(match.group(1)) - int(match.group(2))) - 600
+                earliest_wakeup_time = (
+                    sec_remaining
+                    if sec_remaining < earliest_wakeup_time
+                    else earliest_wakeup_time
+                )
+
+            # find capital and get ambro bonus from fountain if it's active
+            for id in ids:
+                html = session.post(city_url + str(id))
+                if 'class="fountain' in html:  # is capital
+                    if 'class="fountain_active' in html:  # foutain is active
+                        url = "action=AmbrosiaFountainActions&function=collect&backgroundView=city&currentCityId={0}&templateView=ambrosiaFountain&actionRequest={1}&ajax=1".format(
+                            id, actionRequest
+                        )
+                        session.post(url)
+                    break
+                wait(1)
+            earliest_wakeup_time = abs(
+                earliest_wakeup_time
+            )  # funnily enough, it's possible to have the earliest wakeup time be a negative number, this happens if there is less than 10 minutes remaning until tasks reset
+            session.setStatus(
+                f"Last activity @{getDateTime()}, next activity @{getDateTime(time.time()+earliest_wakeup_time)}"
+            )
+            wait(earliest_wakeup_time, 20)
+        except Exception as e:
+            msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
+            sendToBot(session, msg)
+            wait(20 * 60, 20) # wait 20 minutes before retrying if there's an error
+
+
+@configurator
+def loginDaily(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    banner()
+    wine_city = None
+    wood_city = None
+    luxury_city = None
+    favour_tasks = []
+    collect_ambrosia = False
+
+    print("Choose the city where the daily login bonus wine will be sent:")
+    wine_city = chooseCity(session)
+    print("Do you want to automatically activate the cinetheatre bonus? (Y|N)")
+    choice = read(values=["y", "Y", "n", "N"])
+    if choice in ["y", "Y"]:
+
+        # choose city for wood
+        print("Choose the city where the wood bonus will be activated:")
+        wood_city = chooseCity(session)
+
+        # choose city for luxury resource
+        print("Choose the city where the luxury resource bonus will be activated:")
+        luxury_city = chooseCity(session)
+    print("Do you want to automatically collect the 'Divine Imagination' ambrosia bonus? (Y|N)")
+    choice = read(values=["y", "Y", "n", "N"])
+    if choice in ["y", "Y"]:
+        collect_ambrosia = True
+    print("Do you want to collect the favour automatically? (Y|N)")
+    choice = read(values=["y", "Y", "n", "N"])
+    if choice in ["y", "Y"]:
+        favour_tasks = list(TASK_FUNCTIONS.keys())
+
+        def modify_tasks():
+            banner()
+            print(
+                "Choose which daily tasks will be done/collected by Ikabot automatically."
+            )
+            print(
+                f"Tasks in {bcolors.BLUE}blue{bcolors.ENDC} WILL be done automatically, tasks in {bcolors.STONE}grey{bcolors.ENDC} WILL NOT be done."
+            )
+            print("Press [ENTER] or type in [Y] to confirm selection")
+            for i, task_name in enumerate(TASK_FUNCTIONS.keys()):
+                if task_name in favour_tasks:
+                    print(i + 1, ") ", bcolors.BLUE, task_name, bcolors.ENDC)
+                else:
+                    print(i + 1, ") ", bcolors.STONE, task_name, bcolors.ENDC)
+            choice = read(
+                min=1,
+                max=len(TASK_FUNCTIONS),
+                empty=True,
+                digit=True,
+                additionalValues=["y", "Y"],
+            )
+            if not choice or (not choice.isdigit() and choice.lower() == "y"):
+                return
+            choice -= 1
+            task_key = list(TASK_FUNCTIONS.keys())[choice]
+            if task_key in favour_tasks:
+                favour_tasks.remove(task_key)
+            else:
+                favour_tasks.append(task_key)
+            return modify_tasks()
+
+        modify_tasks()
+
+    print("I will do the thing.")
+    enter()
+
+    return {
+        "session": session,
+        "wine_city": wine_city,
+        "wood_city": wood_city,
+        "luxury_city": luxury_city,
+        "favour_tasks": favour_tasks,
+        "collect_ambrosia": collect_ambrosia,
+    }

--- a/ikabot/function/logs.py
+++ b/ikabot/function/logs.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -9,6 +10,7 @@ from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import enter, read
 
 
+@configurator
 def logs(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -18,8 +20,6 @@ def logs(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         while True:
             banner()

--- a/ikabot/function/modifyProduction.py
+++ b/ikabot/function/modifyProduction.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -5,6 +6,7 @@ from ikabot.config import *
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.varios import wait
 
+@configurator
 def modifyProduction(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -14,8 +16,6 @@ def modifyProduction(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         mod_msg = "In which cities do you want to modify production?"
@@ -118,6 +118,7 @@ def modifyProduction(session, event, stdin_fd, predetermined_input):
     event.set()
 
 
+@configurator
 def modifyAcademyWorkers(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -127,8 +128,6 @@ def modifyAcademyWorkers(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         city_ids, _ = ignoreCities(session, msg="In which cities do you want to set academy workers?")
@@ -179,6 +178,7 @@ def modifyAcademyWorkers(session, event, stdin_fd, predetermined_input):
     event.set()
 
 
+@configurator
 def modifyTempleWorkers(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -188,8 +188,6 @@ def modifyTempleWorkers(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         city_ids, _ = ignoreCities(session, msg="In which cities do you want to set priests?")

--- a/ikabot/function/proxyConf.py
+++ b/ikabot/function/proxyConf.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -68,6 +69,7 @@ def read_proxy(session):
     return proxy_dict
 
 
+@configurator
 def proxyConf(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -77,8 +79,6 @@ def proxyConf(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         print(

--- a/ikabot/function/reorganizeCityBuildings.py
+++ b/ikabot/function/reorganizeCityBuildings.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -82,6 +83,7 @@ def _compute_moves(template_city, target_city):
     return moves
 
 
+@configurator
 def reorganizeCityBuildings(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -91,8 +93,6 @@ def reorganizeCityBuildings(session, event, stdin_fd, predetermined_input):
     stdin_fd : int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         print('Select the template city (the layout to copy from):')

--- a/ikabot/function/research.py
+++ b/ikabot/function/research.py
@@ -9,7 +9,7 @@ from ikabot.helpers.botComm import *
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import *
 
@@ -195,181 +195,152 @@ def experiment_multi(session, cities):
             time.sleep(wait)
 
 
+@task("research")
+def do_it(session, mode, experiments=None, automatic=None, cities=None, info=""):
+    setInfoSignal(session, info)
+    if mode == "experiment":
+        experiment(session, experiments, automatic)
+    elif mode == "experiment_multi":
+        experiment_multi(session, cities)
+
+@configurator
 def research(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        while True:
-            banner()
+    while True:
+        banner()
 
-            print("\nSelect an option:")
-            print("0) Back")
-            print("1) Study")
-            print("2) Conduct experiment")
-            print("3) Conduct automatically")
-            option = read(min=0, max=3)
+        print("\nSelect an option:")
+        print("0) Back")
+        print("1) Study")
+        print("2) Conduct experiment")
+        print("3) Conduct automatically")
+        option = read(min=0, max=3)
 
-            if option == 0:
-                event.set()
-                return
+        if option == 0:
+            return None
 
-            if option == 1:
-                try:
-                    studies = get_studies(session)
-                    keys = list(studies.keys())
-                    num_studies = len(
-                        [
-                            key
-                            for key in keys
-                            if "js_researchAdvisorChangeResearchTypeTxt" in key
-                        ]
+        if option == 1:
+            studies = get_studies(session)
+            keys = list(studies.keys())
+            num_studies = len(
+                [
+                    key
+                    for key in keys
+                    if "js_researchAdvisorChangeResearchTypeTxt" in key
+                ]
+            )
+
+            available = []
+            for num_study in range(num_studies):
+                if "js_researchAdvisorProgressTxt{}".format(num_study) in studies:
+                    available.append(num_study)
+
+            if len(available) == 0:
+                print("There are no available studies.")
+                enter()
+                continue
+
+            print("Which one do you wish to study?")
+            print("0) None")
+            for index, num_study in enumerate(available):
+                print(
+                    "{:d}) {}".format(
+                        index + 1,
+                        studies[
+                            "js_researchAdvisorNextResearchName{}".format(num_study)
+                        ],
                     )
+                )
+            choice = read(min=0, max=len(available))
 
-                    available = []
-                    for num_study in range(num_studies):
-                        if "js_researchAdvisorProgressTxt{}".format(num_study) in studies:
-                            available.append(num_study)
+            if choice == 0:
+                continue
 
-                    if len(available) == 0:
-                        print("There are no available studies.")
+            study(session, studies, available[choice - 1])
+            print("Done.")
+            enter()
+        else:
+            if option == 3:
+                banner()
+                academy_cities = find_academy_cities(session)
+
+                if not academy_cities:
+                    print("No academy found in any city.")
+                    enter()
+                    continue
+
+                if len(academy_cities) == 1:
+                    selected_cities = academy_cities
+                else:
+                    print("\nCities with an academy:")
+                    for idx, ac in enumerate(academy_cities, start=1):
+                        print(f"[{idx}] {ac['cityName']}")
+                    print("\nEnter numbers separated by space (e.g. 1 3) or 'all':")
+                    sel = read().strip().lower().split()
+                    if "all" in sel:
+                        selected_cities = academy_cities
+                    else:
+                        selected_cities = []
+                        for token in sel:
+                            if token.isdigit():
+                                i = int(token)
+                                if 0 < i <= len(academy_cities):
+                                    selected_cities.append(academy_cities[i - 1])
+
+                    if not selected_cities:
+                        continue
+
+                city_names = ", ".join(c["cityName"] for c in selected_cities)
+                info = f"Process: Experiments (automatic)\n\nCities: {city_names}\nWill execute every 4h per city"
+                sendToBot(session, info)
+                return {
+                    "mode": "experiment_multi",
+                    "cities": selected_cities,
+                    "info": info
+                }
+            else:
+                automatic = False
+                experiments = {}
+                found_academy = -1
+
+                while True:
+                    banner()
+                    print("Pick city: (Ctrl+C to go back)")
+                    city = chooseCity(session)
+
+                    found_academy = -1
+                    for building in city["position"]:
+                        if building["building"] == "academy":
+                            found_academy = building["position"]
+                            break
+
+                    if found_academy < 0:
+                        print(f"No academy found in {city['name']}, try another city.")
                         enter()
                         continue
 
-                    print("Which one do you wish to study?")
-                    print("0) None")
-                    for index, num_study in enumerate(available):
-                        print(
-                            "{:d}) {}".format(
-                                index + 1,
-                                studies[
-                                    "js_researchAdvisorNextResearchName{}".format(num_study)
-                                ],
-                            )
-                        )
-                    choice = read(min=0, max=len(available))
-
-                    if choice == 0:
+                    total_glass = int(city["availableResources"][3])
+                    if total_glass < 300000:
+                        print(f"Not enough crystal in {city['name']} ({addThousandSeparator(total_glass)}), min=300k. Try another city.")
+                        enter()
                         continue
 
-                    study(session, studies, available[choice - 1])
-                    print("Done.")
-                    enter()
-                except KeyboardInterrupt:
-                    continue
-            else:
-                if option == 3:
-                    try:
-                        banner()
-                        academy_cities = find_academy_cities(session)
+                    break
 
-                        if not academy_cities:
-                            print("No academy found in any city.")
-                            enter()
-                            continue
+                max_experiments = total_glass // 300000
+                banner()
+                print(f"How many experiments? Min=1, Max={max_experiments}")
+                choice = read(min=1, max=max_experiments)
 
-                        if len(academy_cities) == 1:
-                            selected_cities = academy_cities
-                        else:
-                            print("\nCities with an academy:")
-                            for idx, ac in enumerate(academy_cities, start=1):
-                                print(f"[{idx}] {ac['cityName']}")
-                            print("\nEnter numbers separated by space (e.g. 1 3) or 'all':")
-                            sel = read().strip().lower().split()
-                            if "all" in sel:
-                                selected_cities = academy_cities
-                            else:
-                                selected_cities = []
-                                for token in sel:
-                                    if token.isdigit():
-                                        i = int(token)
-                                        if 0 < i <= len(academy_cities):
-                                            selected_cities.append(academy_cities[i - 1])
+                experiments["cityID"] = city["id"]
+                experiments["cityName"] = city["name"]
+                experiments["pos"] = found_academy
+                experiments["qty"] = choice
 
-                            if not selected_cities:
-                                continue
-
-                    except KeyboardInterrupt:
-                        continue
-
-                    set_child_mode(session)
-                    event.set()
-
-                    city_names = ", ".join(c["cityName"] for c in selected_cities)
-                    info = f"Process: Experiments (automatic)\n\nCities: {city_names}\nWill execute every 4h per city"
-
-                    try:
-                        sendToBot(session, info)
-                        experiment_multi(session, selected_cities)
-                    except Exception as e:
-                        error_msg = f"Error in:\n{info}\nCause:\n{traceback.format_exc()}"
-                        sendToBot(session, error_msg)
-                    finally:
-                        session.logout()
-                else:
-                    automatic = False
-                    experiments = {}
-                    found_academy = -1
-
-                    try:
-                        while True:
-                            banner()
-                            print("Pick city: (Ctrl+C to go back)")
-                            city = chooseCity(session)
-
-                            found_academy = -1
-                            for building in city["position"]:
-                                if building["building"] == "academy":
-                                    found_academy = building["position"]
-                                    break
-
-                            if found_academy < 0:
-                                print(f"No academy found in {city['name']}, try another city.")
-                                enter()
-                                continue
-
-                            total_glass = int(city["availableResources"][3])
-                            if total_glass < 300000:
-                                print(f"Not enough crystal in {city['name']} ({addThousandSeparator(total_glass)}), min=300k. Try another city.")
-                                enter()
-                                continue
-
-                            break
-
-                        max_experiments = total_glass // 300000
-                        banner()
-                        print(f"How many experiments? Min=1, Max={max_experiments}")
-                        choice = read(min=1, max=max_experiments)
-
-                        experiments["cityID"] = city["id"]
-                        experiments["cityName"] = city["name"]
-                        experiments["pos"] = found_academy
-                        experiments["qty"] = choice
-
-                    except KeyboardInterrupt:
-                        continue
-
-                    set_child_mode(session)
-                    event.set()
-
-                    info = f"Process: Experiments\n\nWill excecute {choice} times every 4h"
-
-                    try:
-                        sendToBot(session, info)
-                        experiment(session, experiments, automatic)
-                    except Exception as e:
-                        error_msg = f"Error in:\n{info}\nCause:\n{traceback.format_exc()}"
-                        sendToBot(session, error_msg)
-                    finally:
-                        session.logout()
-
-    except KeyboardInterrupt:
-        event.set()
-        return
+                info = f"Process: Experiments\n\nWill excecute {choice} times every 4h"
+                sendToBot(session, info)
+                return {
+                    "mode": "experiment",
+                    "experiments": experiments,
+                    "automatic": automatic,
+                    "info": info
+                }

--- a/ikabot/function/resourceTransportManager.py
+++ b/ikabot/function/resourceTransportManager.py
@@ -14,7 +14,7 @@ from ikabot.helpers.getJson import getCity, getIsland
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.planRoutes import executeRoutes
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.naval import getAvailableShips, getAvailableFreighters
 from ikabot.helpers.varios import addThousandSeparator, getDateTime
@@ -199,59 +199,47 @@ def readResourceAmount(resource_name):
             print("  Please enter a number, 0, leave blank, or press ' to exit")
 
 
+@task("resourceTransportManager")
+def do_it_unified(session, mode, info="", origin_cities=None, destination_city=None, island=None, interval_hours=None, resource_config=None, useFreighters=None, send_mode=None, telegram_enabled=None, notify_on_start=None, origin_city=None, destination_cities=None):
+    setInfoSignal(session, info)
+    if mode == "consolidate":
+        do_it(session, origin_cities, destination_city, island, interval_hours, resource_config, useFreighters, send_mode, telegram_enabled, notify_on_start)
+    elif mode == "distribute":
+        do_it_distribute(session, origin_city, destination_cities, interval_hours, resource_config, useFreighters, telegram_enabled, notify_on_start)
+
+@configurator
 def resourceTransportManager(session, event, stdin_fd, predetermined_input):
-    """
-    Resource Transport Manager - Main entry point
-    
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    
-    try:
-        # Check telegram with skip option
-        telegram_enabled = checkTelegramData(session)
-        if telegram_enabled is False:
-            print_module_banner()
-            print("Telegram notifications are not configured.")
-            print("Do you want to continue without notifications? [Y/n]")
-            rta = read(values=["y", "Y", "n", "N", ""])
-            if rta.lower() == "n":
-                event.set()
-                return
-            # User chose to skip telegram
-            telegram_enabled = None  # Mark as intentionally skipped
-        
-        print_module_banner("Shipping Mode Selection")
-        
-        # Choose shipping mode
-        print("Select shipping mode:")
-        print("(1) Consolidate/Single Shipments: Multiple cities → One destination")
-        print("(2) Distribute: One city → Multiple destinations")
-        print("(') Back to main menu")
-        shipping_mode = read(min=1, max=2, digit=True, additionalValues=["'"])
-        if shipping_mode == "'":
-            event.set()
-            return
-        
-        if shipping_mode == 1:
-            # Existing consolidate mode
-            consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enabled)
-        else:
-            # New distribute mode
-            distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabled)
-            
-    except KeyboardInterrupt:
-        event.set()
-        return
+    # Check telegram with skip option
+    telegram_enabled = checkTelegramData(session)
+    if telegram_enabled is False:
+        print_module_banner()
+        print("Telegram notifications are not configured.")
+        print("Do you want to continue without notifications? [Y/n]")
+        rta = read(values=["y", "Y", "n", "N", ""])
+        if rta.lower() == "n":
+            return None
+        # User chose to skip telegram
+        telegram_enabled = None  # Mark as intentionally skipped
 
+    print_module_banner("Shipping Mode Selection")
 
-def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enabled):
+    # Choose shipping mode
+    print("Select shipping mode:")
+    print("(1) Consolidate/Single Shipments: Multiple cities → One destination")
+    print("(2) Distribute: One city → Multiple destinations")
+    print("(') Back to main menu")
+    shipping_mode = read(min=1, max=2, digit=True, additionalValues=["'"])
+    if shipping_mode == "'":
+        return None
+
+    if shipping_mode == 1:
+        # Existing consolidate mode
+        return consolidateMode(session, telegram_enabled)
+    else:
+        # New distribute mode
+        return distributeMode(session, telegram_enabled)
+
+def consolidateMode(session, telegram_enabled):
     """
     Multiple source cities → Single destination city
     """
@@ -265,8 +253,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("(') Back to main menu")
         shiptype = read(min=1, max=2, digit=True, additionalValues=["'"])
         if shiptype == "'":
-            event.set()
-            return
+            return None
         useFreighters = (shiptype == 2)
         
         print_module_banner("Source City Selection")
@@ -278,8 +265,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("(') Back to main menu")
         source_option = read(min=1, max=2, digit=True, additionalValues=["'"])
         if source_option == "'":
-            event.set()
-            return
+            return None
         
         origin_cities = []
         if source_option == 1:
@@ -299,8 +285,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
             if not source_city_ids:
                 print("No cities selected!")
                 enter()
-                event.set()
-                return
+                return None
             
             # Get full city data for each selected city
             for city_id in source_city_ids:
@@ -324,8 +309,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("(') Back to main menu")
         send_mode = read(min=1, max=2, digit=True, additionalValues=["'"])
         if send_mode == "'":
-            event.set()
-            return
+            return None
         
         print_module_banner("Resource Configuration")
         print(f"Source cities: {source_cities_summary}")
@@ -382,8 +366,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
                 amount = readResourceAmount(resource)
                 
                 if amount == 'EXIT':
-                    event.set()
-                    return
+                    return None
                 
                 # Check if user wants to restart
                 if amount == 'RESTART':
@@ -426,8 +409,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("(') Back to main menu")
         destination_type = read(min=1, max=2, digit=True, additionalValues=["'"])
         if destination_type == "'":
-            event.set()
-            return
+            return None
         
         if destination_type == 2:
             # External city - get island coordinates (with restart support)
@@ -440,8 +422,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
                 
                 x_coord = read(msg="X coordinate: ", digit=True, additionalValues=["'", "="])
                 if x_coord == "'":
-                    event.set()
-                    return
+                    return None
                 
                 if x_coord == "=":
                     print("\nRestarting coordinate entry...\n")
@@ -449,8 +430,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
                 
                 y_coord = read(msg="Y coordinate: ", digit=True, additionalValues=["'", "="])
                 if y_coord == "'":
-                    event.set()
-                    return
+                    return None
                 
                 if y_coord == "=":
                     print("\nRestarting coordinate entry...\n")
@@ -507,8 +487,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
                 city_choice = read(min=0, max=len(cities_on_island), additionalValues=["'", "="])
                 
                 if city_choice == 0 or city_choice == "'":
-                    event.set()
-                    return
+                    return None
                 
                 if city_choice == "=":
                     print("\nRestarting coordinate entry...\n")
@@ -589,8 +568,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
             print("Error: No source cities remaining after excluding destination!")
             print("The destination city was your only source city.")
             enter()
-            event.set()
-            return
+            return None
         
         # Ask about notifications BEFORE schedule (only if telegram is configured)
         if telegram_enabled is None:
@@ -605,8 +583,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
             print("(') Back to main menu")
             notif_choice = read(min=1, max=3, digit=True, additionalValues=["'"])
             if notif_choice == "'":
-                event.set()
-                return
+                return None
             
             # Set notification mode
             if notif_choice == 1:
@@ -627,8 +604,7 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("(Press ' to return to main menu)")
         interval_hours = read(min=0, digit=True, additionalValues=["'"])
         if interval_hours == "'":
-            event.set()
-            return
+            return None
         
         print_module_banner("Configuration Summary")
         
@@ -704,31 +680,29 @@ def consolidateMode(session, event, stdin_fd, predetermined_input, telegram_enab
         print("Proceed? [Y/n]")
         rta = read(values=["y", "Y", "n", "N", ""])
         if rta.lower() == "n":
-            event.set()
-            return
+            return None
         
         enter()
         
     except KeyboardInterrupt:
-        event.set()
-        return
+        return None
     
-    set_child_mode(session)
-    event.set()
-    
-    info = f"\nAuto-send resources from {source_cities_summary} to {destination_city['name']} every {interval_hours} hour(s)\n"
-    setInfoSignal(session, info)
-    
-    try:
-        do_it(session, origin_cities, destination_city, island, interval_hours, resource_config, useFreighters, send_mode, telegram_enabled, notify_on_start)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "mode": "consolidate",
+        "info": info,
+        "origin_cities": origin_cities,
+        "destination_city": destination_city,
+        "island": island,
+        "interval_hours": interval_hours,
+        "resource_config": resource_config,
+        "useFreighters": useFreighters,
+        "send_mode": send_mode,
+        "telegram_enabled": telegram_enabled,
+        "notify_on_start": notify_on_start
+    }
 
 
-def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabled):
+def distributeMode(session, telegram_enabled):
     """
     Single source city → Multiple destination cities
     """
@@ -742,8 +716,7 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
         print("(') Back to main menu")
         shiptype = read(min=1, max=2, digit=True, additionalValues=["'"])
         if shiptype == "'":
-            event.set()
-            return
+            return None
         useFreighters = (shiptype == 2)
         
         print_module_banner("Source City Selection")
@@ -773,8 +746,7 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
         if not destination_city_ids:
             print("No valid destination cities selected!")
             enter()
-            event.set()
-            return
+            return None
         
         # Get full city data for each destination
         destination_cities = []
@@ -808,8 +780,7 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
                 amount = readResourceAmount(resource)
                 
                 if amount == 'EXIT':
-                    event.set()
-                    return
+                    return None
                 
                 # Check if user wants to restart
                 if amount == 'RESTART':
@@ -864,8 +835,7 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
             print("(') Back to main menu")
             notif_choice = read(min=1, max=3, digit=True, additionalValues=["'"])
             if notif_choice == "'":
-                event.set()
-                return
+                return None
             
             # Set notification mode
             if notif_choice == 1:
@@ -886,8 +856,7 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
         print("(Press ' to return to main menu)")
         interval_hours = read(min=0, digit=True, additionalValues=["'"])
         if interval_hours == "'":
-            event.set()
-            return
+            return None
         
         print_module_banner("Configuration Summary")
         
@@ -906,28 +875,24 @@ def distributeMode(session, event, stdin_fd, predetermined_input, telegram_enabl
         print("Proceed? [Y/n]")
         rta = read(values=["y", "Y", "n", "N", ""])
         if rta.lower() == "n":
-            event.set()
-            return
+            return None
         
         enter()
         
     except KeyboardInterrupt:
-        event.set()
-        return
+        return None
     
-    set_child_mode(session)
-    event.set()
-    
-    info = f"\nDistribute resources from {origin_city['name']} to {len(destination_cities)} cities every {interval_hours} hour(s)\n"
-    setInfoSignal(session, info)
-    
-    try:
-        do_it_distribute(session, origin_city, destination_cities, interval_hours, resource_config, useFreighters, telegram_enabled, notify_on_start)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "mode": "distribute",
+        "info": info,
+        "origin_city": origin_city,
+        "destination_cities": destination_cities,
+        "interval_hours": interval_hours,
+        "resource_config": resource_config,
+        "useFreighters": useFreighters,
+        "telegram_enabled": telegram_enabled,
+        "notify_on_start": notify_on_start
+    }
 
 
 def do_it(session, origin_cities, destination_city, island, interval_hours, resource_config, useFreighters, send_mode, telegram_enabled, notify_on_start):

--- a/ikabot/function/searchForIslandSpaces.py
+++ b/ikabot/function/searchForIslandSpaces.py
@@ -7,6 +7,7 @@ import traceback
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.getJson import getIsland
 from ikabot.helpers.gui import enter
 from ikabot.helpers.pedirInfo import getIslandsIds
@@ -14,82 +15,7 @@ from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import getDateTime, wait
 
-
-def searchForIslandSpaces(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        if checkTelegramData(session) is False:
-            event.set()
-            return
-        banner()
-        print(
-            "Do you want to search for spaces on your islands or a specific set of islands?"
-        )
-        print("(0) Exit")
-        print("(1) Search all islands I have colonised")
-        print("(2) Search a specific set of islands")
-        choice = read(min=0, max=2)
-        islandList = []
-        if choice == 0:
-            event.set()
-            return
-        elif choice == 2:
-            banner()
-            print(
-                "Insert the coordinates of each island you want searched like so: X1:Y1, X2:Y2, X3:Y3..."
-            )
-            coords_string = read()
-            coords_string = coords_string.replace(" ", "")
-            coords = coords_string.split(",")
-            for coord in coords:
-                coord = "&xcoord=" + coord
-                coord = coord.replace(":", "&ycoord=")
-                html = session.get("view=island" + coord)
-                island = getIsland(html)
-                islandList.append(island["id"])
-        else:
-            pass
-
-        banner()
-        print(
-            "How frequently should the islands be searched in minutes (minimum is 3)?"
-        )
-        time = read(min=3, digit=True)
-        banner()
-        print(
-            "Do you wish to be notified when a fight breaks out and stops on a city on these islands? (Y|N)"
-        )
-        fights = read(values=["y", "Y", "n", "N"])
-        banner()
-        print("I will search for changes in the selected islands")
-        enter()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI search for new spaces each hour\n"
-    setInfoSignal(session, info)
-    try:
-        do_it(session, islandList, time, fights)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
-
-
+@task("searchForIslandSpaces")
 def do_it(session, islandList, time, fights):
     """
     Parameters
@@ -103,6 +29,8 @@ def do_it(session, islandList, time, fights):
     fights : str
         String that can either be y or n. Indicates whether or not to scan for fight activity on islands
     """
+    info = "\nI search for new spaces each hour\n"
+    setInfoSignal(session, info)
 
     # this dict will contain all the cities from each island
     # as they where in last scan
@@ -206,3 +134,67 @@ def do_it(session, islandList, time, fights):
             f'Checked islands {str([int(i) for i in islandsIds]).replace(" ","")} @ {getDateTime()[-8:]}'
         )
         wait(time * 60)
+
+@configurator
+def searchForIslandSpaces(session, event, stdin_fd, predetermined_input):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    """
+    try:
+        if checkTelegramData(session) is False:
+            return None
+        banner()
+        print(
+            "Do you want to search for spaces on your islands or a specific set of islands?"
+        )
+        print("(0) Exit")
+        print("(1) Search all islands I have colonised")
+        print("(2) Search a specific set of islands")
+        choice = read(min=0, max=2)
+        islandList = []
+        if choice == 0:
+            return None
+        elif choice == 2:
+            banner()
+            print(
+                "Insert the coordinates of each island you want searched like so: X1:Y1, X2:Y2, X3:Y3..."
+            )
+            coords_string = read()
+            coords_string = coords_string.replace(" ", "")
+            coords = coords_string.split(",")
+            for coord in coords:
+                coord = "&xcoord=" + coord
+                coord = coord.replace(":", "&ycoord=")
+                html = session.get("view=island" + coord)
+                island = getIsland(html)
+                islandList.append(island["id"])
+        else:
+            pass
+
+        banner()
+        print(
+            "How frequently should the islands be searched in minutes (minimum is 3)?"
+        )
+        time = read(min=3, digit=True)
+        banner()
+        print(
+            "Do you wish to be notified when a fight breaks out and stops on a city on these islands? (Y|N)"
+        )
+        fights = read(values=["y", "Y", "n", "N"])
+        banner()
+        print("I will search for changes in the selected islands")
+        enter()
+    except KeyboardInterrupt:
+        return None
+
+    return {
+        "session": session,
+        "islandList": islandList,
+        "time": time,
+        "fights": fights
+    }

--- a/ikabot/function/sellResources.py
+++ b/ikabot/function/sellResources.py
@@ -14,7 +14,7 @@ from ikabot.helpers.market import *
 from ikabot.helpers.naval import getTotalShips
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.planRoutes import waitForArrival
-from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import addThousandSeparator, wait, getDateTime
 from ikabot.helpers.pedirInfo import getShipCapacity
@@ -122,14 +122,13 @@ def getOffers(session, my_market_city, resource_type):
     return processed_offers
 
 
-def sellToOffers(session, city_to_buy_from, resource_type, event):
+def sellToOffers(session, city_to_buy_from, resource_type):
     """
     Parameters
     ----------
     session : ikabot.web.session.Session
     city_to_buy_from : dict
     resource_type : int
-    event : multiprocessing.Event
     """
     banner()
 
@@ -138,8 +137,7 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
     if len(offers) == 0:
         print("No offers available.")
         enter()
-        event.set()
-        return
+        return None
 
     print("Which offers do you want to sell to?\n")
 
@@ -166,8 +164,7 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
         profit += amount * price
 
     if len(chosen_offers) == 0:
-        event.set()
-        return
+        return None
 
     available = city_to_buy_from["availableResources"][resource_type]
     amount_to_sell = min(available, total_amount)
@@ -180,8 +177,7 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
     )
     amount_to_sell = read(min=0, max=amount_to_sell)
     if amount_to_sell == 0:
-        event.set()
-        return
+        return None
 
     left_to_sell = amount_to_sell
     profit = 0
@@ -202,35 +198,24 @@ def sellToOffers(session, city_to_buy_from, resource_type, event):
     )
     rta = read(values=["y", "Y", "n", "N", ""])
     if rta.lower() == "n":
-        event.set()
-        return
+        return None
 
-    set_child_mode(session)
-    event.set()
-
-    info = "\nI sell {} of {} in {}\n".format(
-        addThousandSeparator(amount_to_sell),
-        materials_names[resource_type],
-        city_to_buy_from["name"],
-    )
-    setInfoSignal(session, info)
-    try:
-        do_it1(session, amount_to_sell, chosen_offers, resource_type, city_to_buy_from)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "mode": "sell_to_offers",
+        "amount_to_sell": amount_to_sell,
+        "offers": chosen_offers,
+        "resource_type": resource_type,
+        "city_to_buy_from": city_to_buy_from,
+    }
 
 
-def createOffer(session, my_offering_market_city, resource_type, event):
+def createOffer(session, my_offering_market_city, resource_type):
     """
     Parameters
     ----------
     session : ikabot.web.session.Session
     my_offering_market_city : dict
     resource_type : int
-    event : multiprocessing.Event
     """
     banner()
 
@@ -247,8 +232,7 @@ def createOffer(session, my_offering_market_city, resource_type, event):
     )
     amount_to_sell = read(min=0, max=total_available_amount_of_resource)
     if amount_to_sell == 0:
-        event.set()
-        return
+        return None
 
     price_max, price_min = re.findall(r"\'upper\': (\d+),\s*\'lower\': (\d+)", html)[
         resource_type
@@ -269,78 +253,66 @@ def createOffer(session, my_offering_market_city, resource_type, event):
     print("\nProceed? [Y/n]")
     rta = read(values=["y", "Y", "n", "N", ""])
     if rta.lower() == "n":
-        event.set()
-        return
+        return None
 
-    set_child_mode(session)
-    event.set()
+    return {
+        "mode": "create_offer",
+        "amount_to_sell": amount_to_sell,
+        "price": price,
+        "resource_type": resource_type,
+        "sell_market_capacity": sell_market_capacity,
+        "city": my_offering_market_city,
+    }
 
-    info = "\nI sell {} of {} in {}\n".format(
-        addThousandSeparator(amount_to_sell),
-        materials_names[resource_type],
-        my_offering_market_city["name"],
-    )
-    setInfoSignal(session, info)
-    try:
-        do_it2(
-            session,
-            amount_to_sell,
-            price,
-            resource_type,
-            sell_market_capacity,
-            my_offering_market_city,
+
+@task("sellResources")
+def do_it(session, mode, amount_to_sell=None, offers=None, resource_type=None, city_to_buy_from=None, price=None, sell_market_capacity=None, city=None):
+    if mode == "sell_to_offers":
+        info = "\nI sell {} of {} in {}\n".format(
+            addThousandSeparator(amount_to_sell),
+            materials_names[resource_type],
+            city_to_buy_from["name"],
         )
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+        setInfoSignal(session, info)
+        do_it1(session, amount_to_sell, offers, resource_type, city_to_buy_from)
+    elif mode == "create_offer":
+        info = "\nI sell {} of {} in {}\n".format(
+            addThousandSeparator(amount_to_sell),
+            materials_names[resource_type],
+            city["name"],
+        )
+        setInfoSignal(session, info)
+        do_it2(session, amount_to_sell, price, resource_type, sell_market_capacity, city)
 
-
+@configurator
 def sellResources(session, event, stdin_fd, predetermined_input):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
+    banner()
+
+    commercial_cities = getCommercialCities(session)
+    if len(commercial_cities) == 0:
+        print("There is no store built")
+        enter()
+        return None
+
+    if len(commercial_cities) == 1:
+        city = commercial_cities[0]
+    else:
+        city = chooseCommercialCity(commercial_cities)
         banner()
 
-        commercial_cities = getCommercialCities(session)
-        if len(commercial_cities) == 0:
-            print("There is no store built")
-            enter()
-            event.set()
-            return
+    print("What resource do you want to sell?")
+    for index, material_name in enumerate(materials_names):
+        print("({:d}) {}".format(index + 1, material_name))
+    selected_material = read(min=1, max=len(materials_names))
+    resource = selected_material - 1
+    banner()
 
-        if len(commercial_cities) == 1:
-            city = commercial_cities[0]
-        else:
-            city = chooseCommercialCity(commercial_cities)
-            banner()
-
-        print("What resource do you want to sell?")
-        for index, material_name in enumerate(materials_names):
-            print("({:d}) {}".format(index + 1, material_name))
-        selected_material = read(min=1, max=len(materials_names))
-        resource = selected_material - 1
-        banner()
-
-        print(
-            
-            "Do you want to sell to existing offers (1) or do you want to make your own offer (2)?"
-            
-        )
-        selected = read(min=1, max=2)
-        [sellToOffers, createOffer][selected - 1](session, city, resource, event)
-    except KeyboardInterrupt:
-        event.set()
-        return
+    print("Do you want to sell to existing offers (1) or do you want to make your own offer (2)?")
+    selected = read(min=1, max=2)
+    if selected == 1:
+        return sellToOffers(session, city, resource)
+    else:
+        return createOffer(session, city, resource)
 
 
 def do_it1(session, left_to_sell, offers, resource_type, city_to_buy_from):

--- a/ikabot/function/sendResources.py
+++ b/ikabot/function/sendResources.py
@@ -5,16 +5,31 @@ import traceback
 
 from ikabot.config import *
 from ikabot.helpers.botComm import *
+from ikabot.helpers.decorators import configurator, task
 from ikabot.helpers.getJson import getCity
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import *
 from ikabot.helpers.planRoutes import executeRoutes
-from ikabot.helpers.process import set_child_mode
 from ikabot.helpers.resources import *
 from ikabot.helpers.signals import setInfoSignal
 from ikabot.helpers.varios import addThousandSeparator
 
 
+@task("sendResources")
+def do_it(session, routes, useFreighters):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    routes : list
+    useFreighters : bool
+    """
+    info = "\nSend resources\n"
+    setInfoSignal(session, info)
+    executeRoutes(session, routes, useFreighters)
+
+
+@configurator
 def sendResources(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -24,8 +39,6 @@ def sendResources(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         print("What type of ships do you want to use? (Default: Trade ships)")
         print("(1) Trade ships")
@@ -50,8 +63,7 @@ def sendResources(session, event, stdin_fd, predetermined_input):
                     rta = read(values=["y", "Y", "n", "N", ""])
                     if rta.lower() != "n":
                         break
-                event.set()
-                return
+                return None
 
             banner()
             print("Destination city")
@@ -139,19 +151,13 @@ def sendResources(session, event, stdin_fd, predetermined_input):
                 if rta.lower() != "y":
                     break
     except KeyboardInterrupt:
-        event.set()
-        return
+        return None
 
-    set_child_mode(session)
-    event.set()
+    if not routes:
+        return None
 
-    info = "\nSend resources\n"
-
-    setInfoSignal(session, info)
-    try:
-        executeRoutes(session, routes, useFreighters)
-    except Exception as e:
-        msg = "Error in:\n{}\nCause:\n{}".format(info, traceback.format_exc())
-        sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "session": session,
+        "routes": routes,
+        "useFreighters": useFreighters,
+    }

--- a/ikabot/function/shipMovements.py
+++ b/ikabot/function/shipMovements.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -34,6 +35,7 @@ def isHostile(movement):
     return False
 
 
+@configurator
 def shipMovements(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -43,8 +45,6 @@ def shipMovements(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
 

--- a/ikabot/function/stationArmy.py
+++ b/ikabot/function/stationArmy.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 import re
 
 from ikabot.config import *
@@ -134,9 +135,8 @@ def sendArmy(session, origin_city, destination_city, type_army, army_available):
     session.post(params=params)
 
 
+@configurator
 def stationArmy(session, event, stdin_fd, predetermined_input):
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     type_army = True
     try:
         banner()

--- a/ikabot/function/tavernManager.py
+++ b/ikabot/function/tavernManager.py
@@ -412,6 +412,25 @@ def _print_results_table(results):
     print()
 
 
+from ikabot.helpers.decorators import configurator, task
+
+@task("tavernManager")
+def do_tavernManager(session, run_hours, cities_ids, cities, notification_mode):
+    mgr = TavernManager(session, notification_mode)
+    def run_check():
+        results = mgr.process_equilibrium(cities_ids, cities)
+        return results
+
+    info = f"\nTavern Equilibrium: {len(cities_ids)} cities, every {run_hours}h\n"
+    setInfoSignal(session, info)
+
+    while True:
+        wait(run_hours * 3600)
+        run_check()
+        session.setStatus(f"Equilibrium check @{getDateTime()}")
+
+
+@configurator
 def tavernManager(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -421,40 +440,31 @@ def tavernManager(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
+    banner()
 
-    try:
-        banner()
+    print("=" * 60)
+    print("ADVANCED TAVERN WINE CONSUMPTION MANAGER")
+    print("=" * 60)
+    print()
+    print("Select operation mode:")
+    print()
+    print("1. Set tavern level (single city or all cities)")
+    print("2. Equilibrium mode (optimize wine usage)")
+    print()
+    print("(') Back to main menu")
 
-        print("=" * 60)
-        print("ADVANCED TAVERN WINE CONSUMPTION MANAGER")
-        print("=" * 60)
-        print()
-        print("Select operation mode:")
-        print()
-        print("1. Set tavern level (single city or all cities)")
-        print("2. Equilibrium mode (optimize wine usage)")
-        print()
-        print("(') Back to main menu")
+    mode = read(msg="Select mode (1 or 2): ", min=1, max=2, digit=True, additionalValues=["'"])
 
-        mode = read(msg="Select mode (1 or 2): ", min=1, max=2, digit=True, additionalValues=["'"])
+    if mode == "'":
+        return None
 
-        if mode == "'":
-            event.set()
-            return
+    print()
 
-        print()
-
-        if mode == 1:
-            _run_set_mode(session)
-        else:
-            _run_equilibrium_mode(session, event, stdin_fd, predetermined_input)
-
-    except KeyboardInterrupt:
-        pass
-
-    event.set()
+    if mode == 1:
+        _run_set_mode(session)
+        return None
+    else:
+        return _run_equilibrium_mode(session)
 
 
 def _run_set_mode(session):
@@ -511,7 +521,7 @@ def _run_set_mode(session):
     enter()
 
 
-def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
+def _run_equilibrium_mode(session):
     print("=" * 60)
     print("EQUILIBRIUM MODE")
     print("=" * 60)
@@ -529,7 +539,7 @@ def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
     notification_mode = read(msg="Select (1-3): ", min=1, max=3, digit=True, additionalValues=["'"])
 
     if notification_mode == "'":
-        return
+        return None
 
     print()
 
@@ -541,7 +551,7 @@ def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
     city_choice = read(msg="Select (1 or 2): ", min=1, max=2, digit=True, additionalValues=["'"])
 
     if city_choice == "'":
-        return
+        return None
 
     print()
 
@@ -561,7 +571,7 @@ def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
     )
 
     if run_hours == "'":
-        return
+        return None
 
     print()
 
@@ -577,7 +587,7 @@ def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
         print()
         run_check()
         enter()
-        return
+        return None
 
     print(f"Will check {len(cities_ids)} cities every {run_hours} hour(s)")
     print("Running first check...")
@@ -585,21 +595,10 @@ def _run_equilibrium_mode(session, event, stdin_fd, predetermined_input):
     run_check()
     enter()
 
-    set_child_mode(session)
-    event.set()
-
-    info = f"\nTavern Equilibrium: {len(cities_ids)} cities, every {run_hours}h\n"
-    setInfoSignal(session, info)
-
-    try:
-        while True:
-            wait(run_hours * 3600)
-            run_check()
-            session.setStatus(f"Equilibrium check @{getDateTime()}")
-    except Exception:
-        msg = f"Error in:\n{info}\nCause:\n{traceback.format_exc()}"
-        traceback.print_exc()
-        if notification_mode in (1, 2):
-            sendToBot(session, msg)
-    finally:
-        session.logout()
+    return {
+        "session": session,
+        "run_hours": run_hours,
+        "cities_ids": cities_ids,
+        "cities": cities,
+        "notification_mode": notification_mode
+    }

--- a/ikabot/function/testDiscordBot.py
+++ b/ikabot/function/testDiscordBot.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 import sys
@@ -7,6 +8,7 @@ from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import enter, read
 
 
+@configurator
 def testDiscordBot(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -16,8 +18,6 @@ def testDiscordBot(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         if not discordDataIsValid(session):
             print("No Discord webhook configured. Please set it up first.")

--- a/ikabot/function/testTelegramBot.py
+++ b/ikabot/function/testTelegramBot.py
@@ -5,8 +5,10 @@ import sys
 from ikabot.helpers.botComm import sendToBot
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import enter, read
+from ikabot.helpers.decorators import configurator
 
 
+@configurator
 def testTelegramBot(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -16,13 +18,7 @@ def testTelegramBot(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        input = read(msg="Enter the massage you wish to see: ")
-        msg = "Test message: {}".format(input)
-        sendToBot(session, msg)
-        enter()
-        event.set()
-    except KeyboardInterrupt:
-        event.set()
+    input = read(msg="Enter the massage you wish to see: ")
+    msg = "Test message: {}".format(input)
+    sendToBot(session, msg)
+    enter()

--- a/ikabot/function/trainArmy.py
+++ b/ikabot/function/trainArmy.py
@@ -182,7 +182,52 @@ def generateArmyData(units_info):
         i += 1
     return units
 
+from ikabot.helpers.decorators import configurator, task
 
+@task("trainArmy")
+def do_trainArmy(session, city, tranings, trainTroops, replicate, countRepeat, cityTrainings, units):
+    if replicate == "y":
+        countRepeat = countRepeat + 1
+        while countRepeat > 0:
+            for cityId in cityTrainings:
+                html = session.get(city_url + str(cityId))
+                loop_city = getCity(html)
+
+                lookfor = "barracks" if trainTroops else "shipyard"
+                try:
+                    for i in range(len(loop_city["position"])):
+                        if loop_city["position"][i]["building"] == lookfor:
+                            loop_city["pos"] = str(i)
+                            tranings_copy = []
+                            units_copy = copy.deepcopy(units)
+                            tranings_copy.append(units_copy)
+                            planTrainings(
+                                session, loop_city, tranings_copy, trainTroops
+                            )
+                            break
+                except Exception as e:
+                    if trainTroops:
+                        info = "\nI train troops in {}\n".format(
+                            loop_city["cityName"]
+                        )
+                    else:
+                        info = "\nI train fleets in {}\n".format(
+                            loop_city["cityName"]
+                        )
+                    msg = "Error in:\n{}\nCause:\n{}".format(
+                        info, traceback.format_exc()
+                    )
+                    sendToBot(session, msg)
+            countRepeat = countRepeat - 1
+
+    else:
+        if trainTroops:
+            info = "\nI train troops in {}\n".format(city["cityName"])
+        else:
+            info = "\nI train fleets in {}\n".format(city["cityName"])
+        setInfoSignal(session, info)
+        planTrainings(session, city, tranings, trainTroops)
+@configurator
 def trainArmy(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -192,287 +237,232 @@ def trainArmy(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        banner()
+    banner()
 
-        print("Do you want to train troops (1) or ships (2)?")
-        rta = read(min=1, max=2)
-        trainTroops = rta == 1
-        banner()
+    print("Do you want to train troops (1) or ships (2)?")
+    rta = read(min=1, max=2)
+    trainTroops = rta == 1
+    banner()
+
+    if trainTroops:
+        print("In what city do you want to train the troops?")
+    else:
+        print("In what city do you want to train the fleet?")
+    city = chooseCity(session)
+    banner()
+
+    lookfor = "barracks" if trainTroops else "shipyard"
+    for i in range(len(city["position"])):
+        if city["position"][i]["building"] == lookfor:
+            city["pos"] = str(i)
+            break
+    else:
+        if trainTroops:
+            print("Barracks not built.")
+        else:
+            print("Shipyard not built.")
+        enter()
+        return None
+
+    data = getBuildingInfo(session, city, trainTroops)
+
+    units_info = data[2][1]
+    units = generateArmyData(units_info)
+
+    maxSize = max([len(unit["local_name"]) for unit in units])
+
+    tranings = []
+    while True:
+        units = generateArmyData(units_info)
+        print("Train:")
+        for unit in units:
+            pad = " " * (maxSize - len(unit["local_name"]))
+            amount = read(
+                msg="{}{}:".format(pad, unit["local_name"]), min=0, empty=True
+            )
+            if amount == "":
+                amount = 0
+            unit["cantidad"] = amount
+
+        # calculate costs
+        cost = [0] * (len(materials_names_english) + 3)
+        for unit in units:
+            for i in range(len(materials_names_english)):
+                material_name = materials_names_english[i].lower()
+                if material_name in unit["costs"]:
+                    cost[i] += unit["costs"][material_name] * unit["cantidad"]
+
+            if "citizens" in unit["costs"]:
+                cost[len(materials_names_english) + 0] += (
+                    unit["costs"]["citizens"] * unit["cantidad"]
+                )
+            if "upkeep" in unit["costs"]:
+                cost[len(materials_names_english) + 1] += (
+                    unit["costs"]["upkeep"] * unit["cantidad"]
+                )
+            if "completiontime" in unit["costs"]:
+                cost[len(materials_names_english) + 2] += (
+                    unit["costs"]["completiontime"] * unit["cantidad"]
+                )
+
+        print("\nTotal cost:")
+        for i in range(len(materials_names_english)):
+            if cost[i] > 0:
+                print(
+                    "{}: {}".format(
+                        materials_names_english[i], addThousandSeparator(cost[i])
+                    )
+                )
+        if cost[len(materials_names_english) + 0] > 0:
+            print(
+                "Citizens: {}".format(
+                    addThousandSeparator(cost[len(materials_names_english) + 0])
+                )
+            )
+        if cost[len(materials_names_english) + 1] > 0:
+            print(
+                "Maintenance: {}".format(
+                    addThousandSeparator(cost[len(materials_names_english) + 1])
+                )
+            )
+        if cost[len(materials_names_english) + 2] > 0:
+            print(
+                "Duration: {}".format(
+                    daysHoursMinutes(int(cost[len(materials_names_english) + 2]))
+                )
+            )
+
+        print("\nProceed? [Y/n]")
+        rta = read(values=["y", "Y", "n", "N", ""])
+        if rta.lower() == "n":
+            return None
+
+        tranings.append(units)
 
         if trainTroops:
-            print("In what city do you want to train the troops?")
+            print("\nDo you want to train more troops when you finish? [y/N]")
         else:
-            print("In what city do you want to train the fleet?")
-        city = chooseCity(session)
-        banner()
-
-        lookfor = "barracks" if trainTroops else "shipyard"
-        for i in range(len(city["position"])):
-            if city["position"][i]["building"] == lookfor:
-                city["pos"] = str(i)
+            print("\nDo you want to train more fleets when you finish? [y/N]")
+        rta = read(values=["y", "Y", "n", "N", ""])
+        if rta.lower() == "y":
+            banner()
+            if trainTroops:
+                print("Train new troops (1) or repeat (2)?")
+            else:
+                print("Train new fleets (1) or repeat (2)?")
+            rta = read(min=1, max=2)
+            if rta == 1:
+                continue
+            else:
+                print("\nRepeat how many times?")
+                countRepeat = read(min=1, default=0)
                 break
         else:
-            if trainTroops:
-                print("Barracks not built.")
-            else:
-                print("Shipyard not built.")
-            enter()
-            event.set()
-            return
+            countRepeat = 0
+            break
 
-        data = getBuildingInfo(session, city, trainTroops)
+    print("Do you want to replicate the training to other cities? (y/N)")
+    replicate = read(values=["y", "Y", "n", "N", ""])
+    cityTrainings = []
+    if replicate.lower() == "y":
+        ids, cities = getIdsOfCities(session)
 
-        units_info = data[2][1]
-        units = generateArmyData(units_info)
+        print("(0) Back")
+        print("(1) All the wine cities")
+        print("(2) All the marble cities")
+        print("(3) All the cristal cities")
+        print("(4) All the sulfur cities")
+        print("(5) Choose City")
+        print("(6) All City")
 
-        maxSize = max([len(unit["local_name"]) for unit in units])
+        selected = read(min=0, max=6, digit=True)
+        if selected == 0:
+            return None
+        elif selected in [1, 2, 3, 4]:
+            cityTrainings = filterCitiesByResource(
+                cities, resourceMapping[selected], cityTrainings
+            )
+        elif selected == 5:
+            loop_city = []
+            while True:
+                loop_city = chooseCity(session)
+                if loop_city["id"] in cityTrainings:
+                    print("\nYou have already selected this city!")
+                    continue
+                cityTrainings.append(loop_city["id"])
+                print("\nDo you want to add another city? [y/N]")
+                rta = read(values=["y", "Y", "n", "N", ""])
+                if rta.lower() == "y":
+                    continue
+                else:
+                    break
+        elif selected == 6:
+            ids, cities = getIdsOfCities(session)
+            for cityId in ids:
+                cityTrainings.append(cityId)
 
-        tranings = []
-        while True:
-            units = generateArmyData(units_info)
-            print("Train:")
-            for unit in units:
-                pad = " " * (maxSize - len(unit["local_name"]))
-                amount = read(
-                    msg="{}{}:".format(pad, unit["local_name"]), min=0, empty=True
-                )
-                if amount == "":
-                    amount = 0
-                unit["cantidad"] = amount
+    # calculate if the city has enough resources
+    resourcesAvailable = city["availableResources"].copy()
+    resourcesAvailable.append(city["freeCitizens"])
 
-            # calculate costs
-            cost = [0] * (len(materials_names_english) + 3)
-            for unit in units:
+    for training in tranings:
+        for unit in training:
+            if unit["cantidad"] != 0:
                 for i in range(len(materials_names_english)):
                     material_name = materials_names_english[i].lower()
                     if material_name in unit["costs"]:
-                        cost[i] += unit["costs"][material_name] * unit["cantidad"]
+                        resourcesAvailable[i] -= (
+                            unit["costs"][material_name] * unit["cantidad"]
+                        )
 
                 if "citizens" in unit["costs"]:
-                    cost[len(materials_names_english) + 0] += (
+                    resourcesAvailable[len(materials_names_english)] -= (
                         unit["costs"]["citizens"] * unit["cantidad"]
                     )
-                if "upkeep" in unit["costs"]:
-                    cost[len(materials_names_english) + 1] += (
-                        unit["costs"]["upkeep"] * unit["cantidad"]
-                    )
-                if "completiontime" in unit["costs"]:
-                    cost[len(materials_names_english) + 2] += (
-                        unit["costs"]["completiontime"] * unit["cantidad"]
-                    )
 
-            print("\nTotal cost:")
-            for i in range(len(materials_names_english)):
-                if cost[i] > 0:
-                    print(
-                        "{}: {}".format(
-                            materials_names_english[i], addThousandSeparator(cost[i])
-                        )
-                    )
-            if cost[len(materials_names_english) + 0] > 0:
+    not_enough = [elem for elem in resourcesAvailable if elem < 0] != []
+
+    if not_enough:
+        print("\nThere are not enough resources:")
+        for i in range(len(materials_names_english)):
+            if resourcesAvailable[i] < 0:
                 print(
-                    "Citizens: {}".format(
-                        addThousandSeparator(cost[len(materials_names_english) + 0])
-                    )
-                )
-            if cost[len(materials_names_english) + 1] > 0:
-                print(
-                    "Maintenance: {}".format(
-                        addThousandSeparator(cost[len(materials_names_english) + 1])
-                    )
-                )
-            if cost[len(materials_names_english) + 2] > 0:
-                print(
-                    "Duration: {}".format(
-                        daysHoursMinutes(int(cost[len(materials_names_english) + 2]))
+                    "{}:{}".format(
+                        materials_names[i],
+                        addThousandSeparator(resourcesAvailable[i] * -1),
                     )
                 )
 
-            print("\nProceed? [Y/n]")
-            rta = read(values=["y", "Y", "n", "N", ""])
-            if rta.lower() == "n":
-                event.set()
-                return
-
-            tranings.append(units)
-
-            if trainTroops:
-                print("\nDo you want to train more troops when you finish? [y/N]")
-            else:
-                print("\nDo you want to train more fleets when you finish? [y/N]")
-            rta = read(values=["y", "Y", "n", "N", ""])
-            if rta.lower() == "y":
-                banner()
-                if trainTroops:
-                    print("Train new troops (1) or repeat (2)?")
-                else:
-                    print("Train new fleets (1) or repeat (2)?")
-                rta = read(min=1, max=2)
-                if rta == 1:
-                    continue
-                else:
-                    print("\nRepeat how many times?")
-                    countRepeat = read(min=1, default=0)
-                    break
-            else:
-                countRepeat = 0
-                break
-
-        print("Do you want to replicate the training to other cities? (y/N)")
-        replicate = read(values=["y", "Y", "n", "N", ""])
-        if replicate.lower() == "y":
-            cityTrainings = []
-            ids, cities = getIdsOfCities(session)
-
-            print("(0) Back")
-            print("(1) All the wine cities")
-            print("(2) All the marble cities")
-            print("(3) All the cristal cities")
-            print("(4) All the sulfur cities")
-            print("(5) Choose City")
-            print("(6) All City")
-
-            selected = read(min=0, max=6, digit=True)
-            if selected == 0:
-                event.set()
-                return
-            elif selected in [1, 2, 3, 4]:
-                cityTrainings = filterCitiesByResource(
-                    cities, resourceMapping[selected], cityTrainings
-                )
-            elif selected == 5:
-                city = []
-                while True:
-                    city = chooseCity(session)
-                    if city["id"] in cityTrainings:
-                        print("\nYou have already selected this city!")
-                        continue
-                    cityTrainings.append(city["id"])
-                    print("\nDo you want to add another city? [y/N]")
-                    rta = read(values=["y", "Y", "n", "N", ""])
-                    if rta.lower() == "y":
-                        continue
-                    else:
-                        break
-            elif selected == 6:
-                ids, cities = getIdsOfCities(session)
-                for cityId in ids:
-                    cityTrainings.append(cityId)
-
-        # calculate if the city has enough resources
-        resourcesAvailable = city["availableResources"].copy()
-        resourcesAvailable.append(city["freeCitizens"])
-
-        for training in tranings:
-            for unit in training:
-                if unit["cantidad"] != 0:
-                    for i in range(len(materials_names_english)):
-                        material_name = materials_names_english[i].lower()
-                        if material_name in unit["costs"]:
-                            resourcesAvailable[i] -= (
-                                unit["costs"][material_name] * unit["cantidad"]
-                            )
-
-                    if "citizens" in unit["costs"]:
-                        resourcesAvailable[len(materials_names_english)] -= (
-                            unit["costs"]["citizens"] * unit["cantidad"]
-                        )
-
-        not_enough = [elem for elem in resourcesAvailable if elem < 0] != []
-
-        if not_enough:
-            print("\nThere are not enough resources:")
-            for i in range(len(materials_names_english)):
-                if resourcesAvailable[i] < 0:
-                    print(
-                        "{}:{}".format(
-                            materials_names[i],
-                            addThousandSeparator(resourcesAvailable[i] * -1),
-                        )
-                    )
-
-            if resourcesAvailable[len(materials_names_english)] < 0:
-                print(
-                    "Citizens:{}".format(
-                        addThousandSeparator(
-                            resourcesAvailable[len(materials_names_english)] * -1
-                        )
+        if resourcesAvailable[len(materials_names_english)] < 0:
+            print(
+                "Citizens:{}".format(
+                    addThousandSeparator(
+                        resourcesAvailable[len(materials_names_english)] * -1
                     )
                 )
+            )
 
-            print("\nProceed anyway? [Y/n]")
-            rta = read(values=["y", "Y", "n", "N", ""])
-            if rta.lower() == "n":
-                event.set()
-                return
+        print("\nProceed anyway? [Y/n]")
+        rta = read(values=["y", "Y", "n", "N", ""])
+        if rta.lower() == "n":
+            return None
 
-        if trainTroops:
-            print("\nThe selected troops will be trained.")
-        else:
-            print("\nThe selected fleet will be trained.")
-        enter()
+    if trainTroops:
+        print("\nThe selected troops will be trained.")
+    else:
+        print("\nThe selected fleet will be trained.")
+    enter()
 
-        if replicate == "y":
-            countRepeat = countRepeat + 1
-            while countRepeat > 0:
-                for cityId in cityTrainings:
-                    html = session.get(city_url + str(cityId))
-                    city = getCity(html)
-
-                    lookfor = "barracks" if trainTroops else "shipyard"
-                    try:
-                        for i in range(len(city["position"])):
-                            if city["position"][i]["building"] == lookfor:
-                                city["pos"] = str(i)
-                                tranings_copy = []
-                                units_copy = copy.deepcopy(units)
-                                tranings_copy.append(units_copy)
-                                loop = asyncio.get_event_loop()
-                                loop.run_until_complete(
-                                    planTrainings(
-                                        session, city, tranings_copy, trainTroops
-                                    )
-                                )
-                                break
-                    except Exception as e:
-                        if trainTroops:
-                            info = "\nI train troops in {}\n".format(
-                                city["cityName"]
-                            )
-                        else:
-                            info = "\nI train fleets in {}\n".format(
-                                city["cityName"]
-                            )
-                        msg = "Error in:\n{}\nCause:\n{}".format(
-                            info, traceback.format_exc()
-                        )
-                        sendToBot(session, msg)
-                countRepeat = countRepeat - 1
-
-        else:
-            if trainTroops:
-                info = "\nI train troops in {}\n".format(city["cityName"])
-            else:
-                info = "\nI train fleets in {}\n".format(city["cityName"])
-            setInfoSignal(session, info)
-            try:
-                planTrainings(session, city, tranings, trainTroops)
-            except Exception as e:
-                msg = "Error in:\n{}\nCause:\n{}".format(
-                    info, traceback.format_exc()
-                )
-                sendToBot(session, msg)
-            finally:
-                session.logout()
-    except KeyboardInterrupt:
-        event.set()
-        return
-
-    set_child_mode(session)
-    event.set()
+    return {
+        "session": session,
+        "city": city,
+        "tranings": tranings,
+        "trainTroops": trainTroops,
+        "replicate": replicate.lower(),
+        "countRepeat": countRepeat,
+        "cityTrainings": cityTrainings,
+        "units": units
+    }
 
 
 def filterCitiesByResource(cities, resource_id, cityTrainings):

--- a/ikabot/function/update.py
+++ b/ikabot/function/update.py
@@ -7,8 +7,10 @@ from ikabot.config import *
 from ikabot.helpers.gui import *
 from ikabot.helpers.pedirInfo import read
 from ikabot.helpers.process import run
+from ikabot.helpers.decorators import configurator
 
 
+@configurator
 def update(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -18,13 +20,6 @@ def update(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
-    try:
-        print("To update ikabot run:")
-        print("python3 -m pip install --user --upgrade ikabot")
-        enter()
-        event.set()
-    except KeyboardInterrupt:
-        event.set()
-        return
+    print("To update ikabot run:")
+    print("python3 -m pip install --user --upgrade ikabot")
+    enter()

--- a/ikabot/function/vacationMode.py
+++ b/ikabot/function/vacationMode.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
@@ -29,6 +30,7 @@ def activateVacationMode(session):
     session.post(params=data, ignoreExpire=True)
 
 
+@configurator
 def vacationMode(session, event, stdin_fd, predetermined_input):
     """
     Parameters
@@ -38,8 +40,6 @@ def vacationMode(session, event, stdin_fd, predetermined_input):
     stdin_fd: int
     predetermined_input : multiprocessing.managers.SyncManager.list
     """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         print("Activate vacation mode? [Y/n]")

--- a/ikabot/function/viewArmy.py
+++ b/ikabot/function/viewArmy.py
@@ -1,3 +1,4 @@
+from ikabot.helpers.decorators import configurator
 import json
 import os
 import re
@@ -136,9 +137,8 @@ def displaySections(city_names, ids, city_ground, city_ships, cities, show_ships
     print("Grand total: {}".format(addThousandSeparator(grand_total)))
 
 
+@configurator
 def viewArmy(session, event, stdin_fd, predetermined_input):
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
     try:
         banner()
         print("(0) Back")

--- a/ikabot/function/webServer.py
+++ b/ikabot/function/webServer.py
@@ -67,49 +67,15 @@ def get_local_network_ip():
     return None
 
 
-def webServer(session, event, stdin_fd, predetermined_input, port=None):
-    """
-    Parameters
-    ----------
-    session : ikabot.web.session.Session
-    event : multiprocessing.Event
-    stdin_fd: int
-    predetermined_input : multiprocessing.managers.SyncManager.list
-    port : int (optional)
-    """
-    sys.stdin = os.fdopen(stdin_fd)
-    config.predetermined_input = predetermined_input
+from ikabot.helpers.decorators import configurator, task
 
-    banner()
+@task("webServer")
+def do_webServer(session, port, local_network_ip):
     try:
         import flask
         from flask import Flask, Response, request
     except Exception:
-        print(
-            "You must have flask installed for this feature to work. Do you want to install it now?[Y/N]"
-        )
-        choice = read(values=["y", "Y", "n", "N"])
-        if choice in ["y", "Y"]:
-            print(
-                f"Attempting to install flask... -> {bcolors.GREEN}python3 -m pip install flask{bcolors.ENDC}"
-            )
-            command_output = run("python3 -m pip install flask")
-            print(command_output)
-        else:
-            print("Please install flask manually and try to run this module again...")
-            enter()
-            event.set()
-            return
-        try:
-            import flask
-            from flask import Flask, Response, request
-        except Exception:
-            print(
-                "Failed to install flask. Please install it manually and try to run this module again..."
-            )
-            enter()
-            event.set()
-            return
+        return
 
     sys.flask = flask
 
@@ -146,7 +112,7 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
 
         @app.route("/", defaults={"path": ""}, methods=["GET", "POST"])
         @app.route("/<path:path>", methods=["GET", "POST"])
-        def webServer(path):
+        def webServer_route(path):
 
             dest_url = f"{path}"
             
@@ -259,9 +225,6 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
                 web_cache[cache_key] = resp.content
                 return response
 
-            # Replace all instances of the target URL with the proxy URL
-            # modified_content = resp.text.replace(session.urlBase.replace( '/index.php?', ''), 'http://localhost:589').replace(session.host, 'localhost:589')
-
             modified_content = resp.text
 
             # prevent losing reference to console object. sneaky gameforge...
@@ -299,99 +262,140 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
 
             return proxied_response
 
-        def is_port_in_use(port: int) -> bool:
-            try:
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    return s.connect_ex(("127.0.0.1", port)) == 0
-            except Exception as e:
-                logger.log(
-                    logging.FATAL,
-                    f"Error while checking if port {str(port)} is in use: " + str(e),
-                )
-                raise e
-
-        # If the port is not provided, prompt the user for it if enabled from the config file
-        if config.enable_CustomPort is True:
-            while True:
-                if port is None:
-                    print("Please enter a port number (1 - 65535) to run the web server on (leave empty or 0 for random): ")
-                    port = read(min=0, max=65535, digit=True, empty=True)
-                    if port == "" or port == 0:
-                        port = None
-                        break
-                    else:
-                        port = str(int(port))
-                        if is_port_in_use(int(port)):
-                            print(f"Port {port} is already in use, try another port.")
-                            continue
-                        break
-
-        # If the port is still None, select a random port as in the original script
-        if port is None:
-            port = str(
-                (
-                    sum(ord(c) ** 2 for c in session.mail)
-                    + sum(ord(c) ** 2 for c in session.host)
-                    + sum(ord(c) ** 2 for c in session.username)
-                )
-                % 2000
-                + 43000
-            )
-
-            # bang on ports from `port` to 65535 until an available one is found
-            while True:
-                if not is_port_in_use(int(port)):
-                    break
-                port = str(int(port) + 1)
-
-        # try to get local network ip if possible
-        local_network_ip = get_local_network_ip()
-        print(
-            f"""Ikabot web server is about to be run on {bcolors.BLUE}http://127.0.0.1:{port}{bcolors.ENDC} {'and ' + bcolors.BLUE + 'http://' + str(local_network_ip) + ':' + port + bcolors.ENDC if local_network_ip else ''}"""
-        )
-        print(
-            "You can use this link in your browser to play ikariam without logging ikabot out."
-        )
-        print(
-            "If you wish to access this ikabot web server from another device that is not on this local network"
-        )
-        print(
-            "you can try to run one of the following commands in a separate terminal and use the link that it provides to connect:"
-        )
-        print(
-            f"{bcolors.DARK_GREEN}ssh -o StrictHostKeyChecking=no -R 80:127.0.0.1:{port} serveo.net{bcolors.ENDC}"
-        )
-        print("Or you can try:")
-        print(
-            f"{bcolors.DARK_GREEN}ssh -o StrictHostKeyChecking=no -R 80:127.0.0.1:{port} nokey@localhost.run{bcolors.ENDC}"
-        )
-
-        print(
-            f"\n        {bcolors.WARNING}[WARNING]{bcolors.ENDC} Make sure you don't share this link with anyone you don't trust!"
-        )
-
-        print(
-            "\nPress [ENTER] if you want to run the web server now, or CTRL+C to go back to the main menu"
-        )
-        enter()
-        # Ignore Ctrl+C 
-        signal.signal(signal.SIGINT, signal.SIG_IGN)
         session.setStatus(
             f"""running on http://127.0.0.1:{port} {'and '+'http://' + str(local_network_ip) + ':' + port if local_network_ip else ''}"""
         )
-        event.set()
         
         try:
             # use_reloader=False avoid ghost process
             app.run(host="0.0.0.0", port=int(port), threaded=True, use_reloader=False)
         except (KeyboardInterrupt, SystemExit):
             pass
-        finally:
-            event.set()
 
     except Exception:
-        event.set()
-        return
+        pass
+
+
+@configurator
+def webServer(session, event, stdin_fd, predetermined_input, port=None):
+    """
+    Parameters
+    ----------
+    session : ikabot.web.session.Session
+    event : multiprocessing.Event
+    stdin_fd: int
+    predetermined_input : multiprocessing.managers.SyncManager.list
+    port : int (optional)
+    """
+    banner()
+    try:
+        import flask
+        from flask import Flask, Response, request
+    except Exception:
+        print(
+            "You must have flask installed for this feature to work. Do you want to install it now?[Y/N]"
+        )
+        choice = read(values=["y", "Y", "n", "N"])
+        if choice in ["y", "Y"]:
+            print(
+                f"Attempting to install flask... -> {bcolors.GREEN}python3 -m pip install flask{bcolors.ENDC}"
+            )
+            command_output = run("python3 -m pip install flask")
+            print(command_output)
+        else:
+            print("Please install flask manually and try to run this module again...")
+            enter()
+            return None
+        try:
+            import flask
+            from flask import Flask, Response, request
+        except Exception:
+            print(
+                "Failed to install flask. Please install it manually and try to run this module again..."
+            )
+            enter()
+            return None
+
+    def is_port_in_use(port: int) -> bool:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                return s.connect_ex(("127.0.0.1", port)) == 0
+        except Exception as e:
+            return True
+
+    # If the port is not provided, prompt the user for it if enabled from the config file
+    if config.enable_CustomPort is True:
+        while True:
+            if port is None:
+                print("Please enter a port number (1 - 65535) to run the web server on (leave empty or 0 for random): ")
+                port = read(min=0, max=65535, digit=True, empty=True)
+                if port == "" or port == 0:
+                    port = None
+                    break
+                else:
+                    port = str(int(port))
+                    if is_port_in_use(int(port)):
+                        print(f"Port {port} is already in use, try another port.")
+                        continue
+                    break
+
+    # If the port is still None, select a random port as in the original script
+    if port is None:
+        port = str(
+            (
+                sum(ord(c) ** 2 for c in session.mail)
+                + sum(ord(c) ** 2 for c in session.host)
+                + sum(ord(c) ** 2 for c in session.username)
+            )
+            % 2000
+            + 43000
+        )
+
+        # bang on ports from `port` to 65535 until an available one is found
+        while True:
+            if not is_port_in_use(int(port)):
+                break
+            port = str(int(port) + 1)
+
+    # try to get local network ip if possible
+    local_network_ip = get_local_network_ip()
+    print(
+        f"""Ikabot web server is about to be run on {bcolors.BLUE}http://127.0.0.1:{port}{bcolors.ENDC} {'and ' + bcolors.BLUE + 'http://' + str(local_network_ip) + ':' + port + bcolors.ENDC if local_network_ip else ''}"""
+    )
+    print(
+        "You can use this link in your browser to play ikariam without logging ikabot out."
+    )
+    print(
+        "If you wish to access this ikabot web server from another device that is not on this local network"
+    )
+    print(
+        "you can try to run one of the following commands in a separate terminal and use the link that it provides to connect:"
+    )
+    print(
+        f"{bcolors.DARK_GREEN}ssh -o StrictHostKeyChecking=no -R 80:127.0.0.1:{port} serveo.net{bcolors.ENDC}"
+    )
+    print("Or you can try:")
+    print(
+        f"{bcolors.DARK_GREEN}ssh -o StrictHostKeyChecking=no -R 80:127.0.0.1:{port} nokey@localhost.run{bcolors.ENDC}"
+    )
+
+    print(
+        f"\n        {bcolors.WARNING}[WARNING]{bcolors.ENDC} Make sure you don't share this link with anyone you don't trust!"
+    )
+
+    print(
+        "\nPress [ENTER] if you want to run the web server now, or CTRL+C to go back to the main menu"
+    )
+    try:
+        enter()
+    except KeyboardInterrupt:
+        return None
+        
+    return {
+        "session": session,
+        "port": port,
+        "local_network_ip": local_network_ip
+    }
 
 
 def handleIkabotAPIRequest(session, request):

--- a/ikabot/helpers/decorators.py
+++ b/ikabot/helpers/decorators.py
@@ -1,0 +1,215 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Decorators for separating interactive configuration from background task execution.
+
+Every ikabot function module has an interactive configuration phase (the ``@configurator``)
+and optionally a long-running background phase (the ``@task``).
+
+Usage
+-----
+
+**Config-only module** (no background work)::
+
+    @configurator
+    def viewArmy(session, event, stdin_fd, predetermined_input):
+        # ... interactive display ...
+        return None  # signals "nothing to run in background"
+
+**Config + task module**::
+
+    @configurator
+    def alertAttacks(session, event, stdin_fd, predetermined_input):
+        # ... interactive prompts ...
+        minutes = read(msg="How often? ", min=3, default=20)
+        return {"session": session, "minutes": minutes}
+
+    @task("alertAttacks")
+    def do_it(session, minutes):
+        # ALL state needed to run is in the parameters.
+        # This function can be invoked independently.
+        while True:
+            ...
+
+**Blocking configurator** (keeps CLI blocked until task finishes)::
+
+    @configurator(blocking=True)
+    def dumpWorld(session, event, stdin_fd, predetermined_input):
+        ...
+        return {"session": session, "waiting_time": wt, ...}
+
+    @task("dumpWorld")
+    def do_it(session, waiting_time, ...):
+        ...
+"""
+
+import functools
+import os
+import sys
+import traceback
+
+import ikabot.config as config
+from ikabot.helpers.process import set_child_mode
+from ikabot.helpers.signals import setInfoSignal
+
+# ---------------------------------------------------------------------------
+# Task registry
+# ---------------------------------------------------------------------------
+# Maps configurator function name -> task wrapper function.
+# Populated by the @task decorator at import time.
+_TASK_REGISTRY = {}
+
+
+def _send_error(session, info, exc_text):
+    """Best-effort error notification via Telegram/Discord bot."""
+    try:
+        from ikabot.helpers.botComm import sendToBot
+        msg = "Error in:\n{}\nCause:\n{}".format(info, exc_text)
+        sendToBot(session, msg)
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# @task decorator
+# ---------------------------------------------------------------------------
+
+def task(configurator_name):
+    """Register a background task function for a given configurator.
+
+    Parameters
+    ----------
+    configurator_name : str
+        The ``__name__`` of the ``@configurator``-decorated function this task
+        belongs to.  This is used as the lookup key so the configurator can
+        find and invoke its task automatically.
+
+    The decorated function **must** accept all its runtime state as explicit
+    keyword parameters (no reliance on module-level globals for configuration).
+    The configurator returns a dict whose keys match the task's parameter names.
+    The first positional argument is conventionally ``session``.
+
+    The decorator automatically:
+    * calls ``session.logout()`` in a ``finally`` block
+    * catches unhandled exceptions and forwards them to the user via
+      ``sendToBot``
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            # Determine session: first positional arg, or keyword 'session'
+            session = kwargs.get("session") or (args[0] if args else None)
+            try:
+                return func(*args, **kwargs)
+            except Exception:
+                _send_error(session, func.__name__, traceback.format_exc())
+                raise
+            finally:
+                if session is not None and hasattr(session, "logout"):
+                    try:
+                        session.logout()
+                    except Exception:
+                        pass
+
+        # Register in the global task registry
+        _TASK_REGISTRY[configurator_name] = wrapper
+        # Keep a reference to the original unwrapped function for direct use
+        wrapper.__wrapped__ = func
+        return wrapper
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# @configurator decorator
+# ---------------------------------------------------------------------------
+
+def configurator(_func=None, *, blocking=False):
+    """Mark a function as a module's interactive configuration entry point.
+
+    Parameters
+    ----------
+    blocking : bool, optional
+        If ``True``, the CLI menu stays blocked until the task finishes
+        (used by modules like ``dumpWorld`` that show a live progress UI).
+        Default is ``False`` (the normal case where the CLI is released
+        immediately after configuration so the user can queue more tasks).
+
+    The decorated function must have the standard ikabot entry signature::
+
+        def func(session, event, stdin_fd, predetermined_input):
+
+    It should **return** one of:
+
+    * ``None`` — config-only module, no background task to run.
+    * a ``dict`` — keyword arguments to pass to the matching ``@task``
+      function.  The dict keys must match the task function's parameter
+      names exactly.  The dict **must** include ``"session"`` so the task
+      has access to the game session.
+
+    The decorator handles:
+    * ``sys.stdin = os.fdopen(stdin_fd)``
+    * ``config.predetermined_input = predetermined_input``
+    * ``set_child_mode(session)`` + ``event.set()`` handoff (unless blocking)
+    * ``event.set()`` for config-only modules
+    * ``KeyboardInterrupt`` handling
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(session, event, stdin_fd, predetermined_input):
+            # Set up stdin and predetermined input for the child process
+            try:
+                if stdin_fd is not None:
+                    sys.stdin = os.fdopen(stdin_fd)
+            except Exception:
+                pass
+            config.predetermined_input = predetermined_input
+
+            try:
+                result = func(session, event, stdin_fd, predetermined_input)
+            except KeyboardInterrupt:
+                event.set()
+                return
+            except Exception:
+                event.set()
+                raise
+
+            if result is None:
+                # Config-only module — signal completion and exit
+                event.set()
+                return
+
+            # Config + task module — look up the registered task
+            task_func = _TASK_REGISTRY.get(func.__name__)
+            if task_func is None:
+                # No @task registered for this configurator — treat as
+                # config-only (this is a programming error, but fail safe)
+                event.set()
+                return
+
+            if blocking:
+                # Blocking mode: run the task, THEN release the CLI
+                try:
+                    task_func(**result)
+                finally:
+                    event.set()
+            else:
+                # Normal mode: release the CLI, then run the task in background
+                set_child_mode(session)
+                event.set()
+                task_func(**result)
+
+        # Preserve metadata for introspection
+        wrapper._is_configurator = True
+        wrapper._blocking = blocking
+        return wrapper
+
+    # Support both @configurator and @configurator(blocking=True) syntax
+    if _func is not None:
+        # Called as @configurator without parentheses
+        return decorator(_func)
+    # Called as @configurator(...) with keyword arguments
+    return decorator

--- a/tests/ikabot/helpers/test_decorators.py
+++ b/tests/ikabot/helpers/test_decorators.py
@@ -1,0 +1,104 @@
+import multiprocessing
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from ikabot.helpers.decorators import (
+    _TASK_REGISTRY,
+    configurator,
+    task,
+)
+
+
+class TestDecorators(unittest.TestCase):
+    def setUp(self):
+        self.session = MagicMock()
+        self.session.logout = MagicMock()
+        self.event = multiprocessing.Event()
+
+    def test_config_only_module_returns_none(self):
+        @configurator
+        def dummy_config_only(session, event, stdin_fd, predetermined_input):
+            return None
+
+        # Call configurator
+        dummy_config_only(self.session, self.event, None, [])
+        self.assertTrue(self.event.is_set())
+
+    @patch("ikabot.helpers.decorators.set_child_mode")
+    def test_config_and_task_handoff(self, mock_set_child_mode):
+        executed_task_kwargs = {}
+
+        @task("dummy_feature")
+        def dummy_task(session, city_id, amount):
+            executed_task_kwargs["session"] = session
+            executed_task_kwargs["city_id"] = city_id
+            executed_task_kwargs["amount"] = amount
+
+        @configurator
+        def dummy_feature(session, event, stdin_fd, predetermined_input):
+            return {
+                "session": session,
+                "city_id": 42,
+                "amount": 1000,
+            }
+
+        dummy_feature(self.session, self.event, None, [])
+
+        # Verify child mode was set and event was signaled
+        mock_set_child_mode.assert_called_once_with(self.session)
+        self.assertTrue(self.event.is_set())
+
+        # Verify task received exact kwargs
+        self.assertEqual(executed_task_kwargs["session"], self.session)
+        self.assertEqual(executed_task_kwargs["city_id"], 42)
+        self.assertEqual(executed_task_kwargs["amount"], 1000)
+
+        # Verify session.logout() was automatically called
+        self.session.logout.assert_called_once()
+
+    @patch("ikabot.helpers.decorators.set_child_mode")
+    def test_blocking_configurator(self, mock_set_child_mode):
+        order_of_execution = []
+
+        @task("blocking_feature")
+        def blocking_task(session):
+            order_of_execution.append("task_executed")
+
+        @configurator(blocking=True)
+        def blocking_feature(session, event, stdin_fd, predetermined_input):
+            return {"session": session}
+
+        blocking_feature(self.session, self.event, None, [])
+
+        # In blocking mode, child mode is not set and task finishes before event.set()
+        self.assertEqual(order_of_execution, ["task_executed"])
+        self.assertTrue(self.event.is_set())
+        mock_set_child_mode.assert_not_called()
+        self.session.logout.assert_called_once()
+
+    @patch("ikabot.helpers.decorators._send_error")
+    def test_task_error_handling_and_logout(self, mock_send_error):
+        @task("failing_feature")
+        def failing_task(session):
+            raise ValueError("Something went wrong")
+
+        @configurator
+        def failing_feature(session, event, stdin_fd, predetermined_input):
+            return {"session": session}
+
+        with self.assertRaises(ValueError):
+            failing_feature(self.session, self.event, None, [])
+
+        # Error notification called and logout called even on exception
+        mock_send_error.assert_called_once()
+        self.session.logout.assert_called_once()
+
+    def test_keyboard_interrupt_in_configurator(self):
+        @configurator
+        def interrupted_feature(session, event, stdin_fd, predetermined_input):
+            raise KeyboardInterrupt()
+
+        interrupted_feature(self.session, self.event, None, [])
+        self.assertTrue(self.event.is_set())


### PR DESCRIPTION
Introduce @configurator and @task decorators to decouple module configuration from background execution. Pass all task parameters explicitly via keyword arguments from configurator return dictionaries.

This change is intended to pave the way for running tasks without having to run the ikabot main menu CLI. This would allow for a more robust implementation of command line parameters instead of having to rely in predetermined input (think someone typing in `ikabot --email myemail@example.com --password myPassword123 --task autoPirate --taskConfig {'count': 100, 'mission': 1, 'maxRandomWaitingTime': 10, 'piracyCity':123}` )

It will also allow for restarting tasks without having to reconfigure them via the CLI which can be obnoxious... Imagine someone having 10 tasks running, they all die and now they have to be reconfigured manually. With this, we could save the background task config and just run the task again with that same config. It also create an opportunity to make some sort of task-persistence where tasks will revive themselves some number of times after failing for whatever reason (network reasons etc...)

It's worth noting that not all ikabot functions have a background executor. Some of them simply display information to the console and leave no process behind once the user finishes viewing the task. For these tasks the name "configurator" is a little bit of a misnomer, because they don't configure anything, but that isn't a big issue right now.