### PR TITLE
Proactively invalidate the actionRequest token after action requests

### DIFF
--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -1581,6 +1581,13 @@ class Session:
                 except Exception:
                     pass
 
+                # 'action' requests always need a fresh token afterward
+                if "action" in payloadPost or "action" in params:
+                    sessionData = self.getSessionData()
+                    if sessionData.pop("actionRequestToken", None) is not None:
+                        sessionData.pop("shared", None)
+                        self.setSessionData(sessionData)
+
                 return resp if not fullResponse else response
             except AssertionError:
                 self.__sessionExpired()


### PR DESCRIPTION
'action' requests always consume the actionRequest token and require a fresh one afterward, while 'view' navigation keeps reusing the same token. Session.post() now clears the cached token right after a successful 'action' request instead of waiting to be rejected on the next one, avoiding an extra failed-then-retried round trip.