### PR TITLE
Dedup processList entries by pid instead of by full dict

### DIFF
--- a/ikabot/helpers/process.py
+++ b/ikabot/helpers/process.py
@@ -68,10 +68,12 @@ def updateProcessList(session, programprocesslist=[]):
         if proc.name() == ika_process and isAlive:
             runningIkabotProcessList.append(process)
 
-    # add new to the list and write to file only if it's given
+    # add new to the list and write to file only if it's given (dedup by pid)
+    existing_pids = {p["pid"] for p in runningIkabotProcessList}
     for process in programprocesslist:
-        if process not in runningIkabotProcessList:
+        if process["pid"] not in existing_pids:
             runningIkabotProcessList.append(process)
+            existing_pids.add(process["pid"])
 
     # check if all proceses have new status field
     if len([p for p in runningIkabotProcessList if "status" not in p]) == len(


### PR DESCRIPTION
This solution is important for predefined input tests.

A process registering itself with a fresh 'started' entry could race with that same process already having written a more current status, producing two entries for the same pid since the old check compared whole dicts. One of the two would then get shown/killed arbitrarily depending on list order. Comparing by pid instead avoids the duplicate.